### PR TITLE
Keep blooming time synchronized with the first pour

### DIFF
--- a/apps/brewlog/src/components/forms/BrewLogFields.tsx
+++ b/apps/brewlog/src/components/forms/BrewLogFields.tsx
@@ -545,13 +545,15 @@ export const BrewLogFields = ({
                           ) : (
                             <select
                               value={pour.duration}
-                              onChange={(event) =>
+                              onChange={(event) => {
+                                const duration = Number(event.target.value);
                                 field.handleChange(
                                   updatePour(values, index, {
-                                    duration: Number(event.target.value),
+                                    duration,
                                   }),
-                                )
-                              }
+                                );
+                                if (index === 0) form.setFieldValue("bloomingTime", duration);
+                              }}
                               className="h-8 flex-1 rounded-lg border bg-white px-1 text-xs text-center"
                               required
                             >


### PR DESCRIPTION
### Motivation

- When the user changed the first pour's duration only `pours[0].duration` was updated while `bloomingTime` could remain out of sync, causing inconsistent persisted values.

### Description

- Updated the pour-duration `onChange` handler in `apps/brewlog/src/components/forms/BrewLogFields.tsx` to parse the selected value once into a `duration` variable and reuse it for the pour update.
- When `index === 0` the handler now also sets the form field `bloomingTime` to the same parsed `duration` so the two controls stay synchronized.
- Later pours keep their prior behaviour and remain independent, only updating their own `duration` values.

### Testing

- Ran `vp check --fix`; formatting and linting completed with no warnings.
- Ran `vp test`; unit tests passed (30 tests across 2 files).
- Ran `./scripts/check-betterleaks-canary.sh`; the canary could not be executed in this environment because `betterleaks` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c274914b48321acc32787c59d327a)