### PR TITLE
fix(brewlog): validate grinder form on blur

### DIFF
--- a/apps/brewlog/src/components/forms/formValidation.ts
+++ b/apps/brewlog/src/components/forms/formValidation.ts
@@ -1,0 +1,9 @@
+export const getFirstValidationError = (errors: readonly unknown[]) => {
+  const error = errors[0];
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === "object" && "message" in error) {
+    return typeof error.message === "string" ? error.message : null;
+  }
+  return error ? "入力内容を確認してください。" : null;
+};

--- a/apps/brewlog/src/components/forms/grinderForm.ts
+++ b/apps/brewlog/src/components/forms/grinderForm.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+const thresholdSchema = z.union([
+  z
+    .number()
+    .int("整数で入力してください。")
+    .min(1, "1以上で入力してください。")
+    .max(40, "40以下で入力してください。"),
+  z.literal(""),
+]);
+
+export const grinderFormSchema = z
+  .object({
+    name: z.string().refine((name) => name.trim().length > 0, {
+      message: "グラインダー名を入力してください。",
+    }),
+    fineMax: thresholdSchema,
+    mediumFineMax: thresholdSchema,
+    mediumMax: thresholdSchema,
+    mediumCoarseMax: thresholdSchema,
+    isDefault: z.boolean(),
+  })
+  .superRefine((value, context) => {
+    const thresholds = [value.fineMax, value.mediumFineMax, value.mediumMax, value.mediumCoarseMax];
+
+    if (thresholds.some((threshold) => threshold === "")) {
+      context.addIssue({
+        code: "custom",
+        message: "すべての境界値を入力してください。",
+      });
+      return;
+    }
+
+    const [fineMax, mediumFineMax, mediumMax, mediumCoarseMax] = thresholds as [
+      number,
+      number,
+      number,
+      number,
+    ];
+    if (fineMax >= mediumFineMax || mediumFineMax >= mediumMax || mediumMax >= mediumCoarseMax) {
+      context.addIssue({
+        code: "custom",
+        message: "境界値は細挽きから粗挽きへ昇順にしてください。",
+      });
+    }
+  });
+
+export type GrinderFormValues = z.infer<typeof grinderFormSchema>;

--- a/apps/brewlog/src/pages/Settings/Grinders.tsx
+++ b/apps/brewlog/src/pages/Settings/Grinders.tsx
@@ -3,22 +3,14 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { ArrowLeft, CheckCircle, Loader2, Pencil, Plus, Sliders, Trash2 } from "lucide-react";
-import { grinderCreateSchema, grinderUpdateSchema } from "@/contracts";
 import { grinderQueries, mutations, queryKeys, type Grinder } from "@/lib/queries";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type { FormApiLike } from "@/components/forms/types";
-
-type GrinderFormValues = {
-  name: string;
-  fineMax: number | "";
-  mediumFineMax: number | "";
-  mediumMax: number | "";
-  mediumCoarseMax: number | "";
-  isDefault: boolean;
-};
+import { getFirstValidationError } from "@/components/forms/formValidation";
+import { grinderFormSchema, type GrinderFormValues } from "@/components/forms/grinderForm";
 
 const emptyValues: GrinderFormValues = {
   name: "",
@@ -192,25 +184,11 @@ const Grinders = () => {
   });
   const form = useForm({
     defaultValues: emptyValues,
+    validators: {
+      onBlur: grinderFormSchema,
+      onSubmit: grinderFormSchema,
+    },
     onSubmit: async ({ value }) => {
-      if (
-        value.fineMax === "" ||
-        value.mediumFineMax === "" ||
-        value.mediumMax === "" ||
-        value.mediumCoarseMax === ""
-      )
-        throw new Error("すべての境界値を入力してください。");
-      if (
-        value.fineMax >= value.mediumFineMax ||
-        value.mediumFineMax >= value.mediumMax ||
-        value.mediumMax >= value.mediumCoarseMax
-      )
-        throw new Error("境界値は細挽きから粗挽きへ昇順にしてください。");
-      const payload = toPayload(value);
-      const parsed = editingId
-        ? grinderUpdateSchema.safeParse(payload)
-        : grinderCreateSchema.safeParse(payload);
-      if (!parsed.success) throw new Error("入力内容を確認してください。");
       if (editingId) await updateMutation.mutateAsync({ id: editingId, value });
       else await createMutation.mutateAsync(value);
     },
@@ -266,6 +244,16 @@ const Grinders = () => {
           )}
         </div>
         <GrinderFields form={form} isSubmitting={isSubmitting} />
+        <form.Subscribe selector={(state) => state.errors}>
+          {(errors) => {
+            const validationError = getFirstValidationError(errors);
+            return validationError ? (
+              <p className="text-xs text-red-600" role="alert">
+                {validationError}
+              </p>
+            ) : null;
+          }}
+        </form.Subscribe>
         <div className="flex gap-2">
           {editingId && (
             <Button


### PR DESCRIPTION
### Motivation

- Prevent unobserved exceptions thrown from `onSubmit` when grinder threshold validation fails and surface those validation errors to users instead of letting the form silently reject.
- Run validation both on submit and on blur so users get earlier feedback without altering the existing mutation/error UI flow.

### Description

- Add a shared Zod form schema `grinderFormSchema` to `apps/brewlog/src/components/forms/grinderForm.ts` that validates name, integer thresholds, ranges and enforces strict ascending order of the four thresholds.
- Add a small helper `getFirstValidationError` in `apps/brewlog/src/components/forms/formValidation.ts` to format the first form validation error for display.
- Wire the schema into the page form by setting `validators.onBlur` and `validators.onSubmit` in `apps/brewlog/src/pages/Settings/Grinders.tsx` and remove the previous `throw`-based validation from `onSubmit`, making `onSubmit` only perform create/update mutations when validators pass.
- Subscribe to the form error state with `form.Subscribe` and render a user-facing error message (`role=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c2a9400d88321ba496847d9bff812)