### PR TITLE
fix(brewlog): reject failed API responses in queries and mutations

### DIFF
--- a/apps/brewlog/src/lib/queries.ts
+++ b/apps/brewlog/src/lib/queries.ts
@@ -1,7 +1,17 @@
 import { parseResponse } from "hono/client";
-import type { InferRequestType, InferResponseType } from "hono/client";
+import type { ClientResponse, InferRequestType, InferResponseType } from "hono/client";
 import { queryOptions } from "@tanstack/react-query";
 import { api } from "./api";
+
+const parseOkResponse = async <T extends ClientResponse<unknown>>(responsePromise: Promise<T>) => {
+  const response = await responsePromise;
+
+  if (!response.ok) {
+    throw new Error(`API request failed: ${response.status} ${response.statusText}`);
+  }
+
+  return parseResponse(response);
+};
 
 export const queryKeys = {
   beans: ["brewlog", "beans"] as const,
@@ -27,12 +37,12 @@ export const beanQueries = {
   all: () =>
     queryOptions({
       queryKey: queryKeys.beans,
-      queryFn: () => parseResponse(api.api.beans.$get()),
+      queryFn: () => parseOkResponse(api.api.beans.$get()),
     }),
   detail: (id: string) =>
     queryOptions({
       queryKey: queryKeys.bean(id),
-      queryFn: () => parseResponse(api.api.beans[":id"].$get({ param: { id } })),
+      queryFn: () => parseOkResponse(api.api.beans[":id"].$get({ param: { id } })),
       enabled: Boolean(id),
     }),
 };
@@ -41,12 +51,12 @@ export const logQueries = {
   all: () =>
     queryOptions({
       queryKey: queryKeys.logs,
-      queryFn: () => parseResponse(api.api.logs.$get()),
+      queryFn: () => parseOkResponse(api.api.logs.$get()),
     }),
   detail: (id: string) =>
     queryOptions({
       queryKey: queryKeys.log(id),
-      queryFn: () => parseResponse(api.api.logs[":id"].$get({ param: { id } })),
+      queryFn: () => parseOkResponse(api.api.logs[":id"].$get({ param: { id } })),
       enabled: Boolean(id),
     }),
 };
@@ -55,7 +65,7 @@ export const dripperQueries = {
   all: () =>
     queryOptions({
       queryKey: queryKeys.drippers,
-      queryFn: () => parseResponse(api.api.drippers.$get()),
+      queryFn: () => parseOkResponse(api.api.drippers.$get()),
     }),
 };
 
@@ -63,7 +73,7 @@ export const grinderQueries = {
   all: () =>
     queryOptions({
       queryKey: queryKeys.grinders,
-      queryFn: () => parseResponse(api.api.grinders.$get()),
+      queryFn: () => parseOkResponse(api.api.grinders.$get()),
     }),
 };
 
@@ -77,16 +87,20 @@ export type CreateGrinderRequest = InferRequestType<typeof api.api.grinders.$pos
 export type UpdateGrinderRequest = InferRequestType<(typeof api.api.grinders)[":id"]["$patch"]>;
 
 export const mutations = {
-  createBean: (options: CreateBeanRequest) => parseResponse(api.api.beans.$post(options)),
-  updateBean: (options: UpdateBeanRequest) => parseResponse(api.api.beans[":id"].$patch(options)),
-  createLog: (options: CreateLogRequest) => parseResponse(api.api.logs.$post(options)),
-  updateLog: (options: UpdateLogRequest) => parseResponse(api.api.logs[":id"].$patch(options)),
-  createDripper: (options: CreateDripperRequest) => parseResponse(api.api.drippers.$post(options)),
+  createBean: (options: CreateBeanRequest) => parseOkResponse(api.api.beans.$post(options)),
+  updateBean: (options: UpdateBeanRequest) => parseOkResponse(api.api.beans[":id"].$patch(options)),
+  createLog: (options: CreateLogRequest) => parseOkResponse(api.api.logs.$post(options)),
+  updateLog: (options: UpdateLogRequest) => parseOkResponse(api.api.logs[":id"].$patch(options)),
+  createDripper: (options: CreateDripperRequest) =>
+    parseOkResponse(api.api.drippers.$post(options)),
   updateDripper: (options: UpdateDripperRequest) =>
-    parseResponse(api.api.drippers[":id"].$patch(options)),
-  deleteDripper: (id: string) => parseResponse(api.api.drippers[":id"].$delete({ param: { id } })),
-  createGrinder: (options: CreateGrinderRequest) => parseResponse(api.api.grinders.$post(options)),
+    parseOkResponse(api.api.drippers[":id"].$patch(options)),
+  deleteDripper: (id: string) =>
+    parseOkResponse(api.api.drippers[":id"].$delete({ param: { id } })),
+  createGrinder: (options: CreateGrinderRequest) =>
+    parseOkResponse(api.api.grinders.$post(options)),
   updateGrinder: (options: UpdateGrinderRequest) =>
-    parseResponse(api.api.grinders[":id"].$patch(options)),
-  deleteGrinder: (id: string) => parseResponse(api.api.grinders[":id"].$delete({ param: { id } })),
+    parseOkResponse(api.api.grinders[":id"].$patch(options)),
+  deleteGrinder: (id: string) =>
+    parseOkResponse(api.api.grinders[":id"].$delete({ param: { id } })),
 };


### PR DESCRIPTION
### Motivation

- Hono's `parseResponse` can resolve for non-OK HTTP responses which allows error payloads to be parsed and cached as successful data, and lets mutation success handlers run on failed requests. This leads to runtime crashes and incorrect UI behavior.

### Description

- Add a `parseOkResponse` helper that awaits the `ClientResponse`, checks `response.ok`, throws a descriptive error for non-OK status codes, and only then calls `parseResponse` to parse the body.
- Import `ClientResponse` from `hono/client` and replace direct `parseResponse(...)` calls with `parseOkResponse(...)` for all list/detail query functions and for every create/update/delete mutation in `apps/brewlog/src/lib/queries.ts`.
- Ensure queries no longer cache error responses and mutations reject on HTTP errors so callers only receive parsed data for successful requests.

### Testing

- Ran formatting/lint/type checks via the repository check tasks (`pnpm --filter brewlog check:fix` and the workspace `turbo run check`) and they completed with no warnings or errors.
- Ran unit tests for the Brewlog package (`pnpm --filter brewlog test`) and all tests passed (2 test files, 30 tests passed).
- Executed pre-commit guard checks (secret scan / betterleaks and application checks) and they completed successfully in the environment used for verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c2743cc04832193b5e734e3fc3b03)