### PR TITLE
fix(cafelog): セグメントの視認性を改善

### DIFF
--- a/packages/ui/src/components/segment.tsx
+++ b/packages/ui/src/components/segment.tsx
@@ -27,7 +27,7 @@ export function Segment<T extends string>({
     <div
       role="radiogroup"
       aria-label={ariaLabel}
-      className={cn("grid grid-flow-col auto-cols-fr gap-1 rounded-xl border border-border bg-muted p-1", className)}
+      className={cn("grid grid-flow-col auto-cols-fr gap-1 rounded-2xl bg-muted/10 p-1", className)}
     >
       {options.map((option) => {
         const selected = value === option.value;
@@ -36,8 +36,10 @@ export function Segment<T extends string>({
           <label
             key={option.value}
             className={cn(
-              "cursor-pointer rounded-lg px-3 py-2.5 text-center text-xs font-bold transition-all has-focus-visible:ring-2 has-focus-visible:ring-ring active:scale-[0.98]",
-              selected ? "bg-primary text-primary-foreground shadow-sm" : "text-muted hover:bg-primary/5 hover:text-primary",
+              "cursor-pointer rounded-xl px-3 py-2.5 text-center text-xs font-bold transition-all has-focus-visible:ring-2 has-focus-visible:ring-ring active:scale-[0.98]",
+              selected
+                ? "bg-surface text-primary shadow-sm"
+                : "text-muted hover:bg-surface/60 hover:text-primary",
             )}
           >
             <input


### PR DESCRIPTION
### Motivation
- Cafelog のセグメントUIが白抜きや文字が選択されるまで表示されない等で視認性が低かったため、Brewlog の選択コンポーネントを参考に表示性を改善する。 

### Description
- `packages/ui/src/components/segment.tsx` のスタイルを調整し、ラジオグループの背景を薄いサーフェスに変更して選択中は白いサーフェス＋プライマリ文字色で表示するようにした。 
- 未選択項目の文字色とホバー状態を改善して、選択前に文字が見えない問題を解消した。 
- 既存のセマンティクス（`role=

Close #10

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a93e93fd71c8321ad4e890de6e1d3e2)