### PR TITLE
fix(brewlog): 日付入力がフォーム幅からはみ出す問題を修正

### DIFF
--- a/apps/brewlog/src/index.css
+++ b/apps/brewlog/src/index.css
@@ -44,12 +44,11 @@ body {
   width: 100%;
 }
 
-/* Keep native date controls inside the form width in mobile WebViews. */
+/* Remove WebKit's intrinsic date-field sizing so it respects the shared Input width. */
 input[type="date"] {
-  box-sizing: border-box;
-  width: 100%;
-  min-width: 0;
-  max-width: 100%;
+  -webkit-appearance: none;
+  appearance: none;
+  overflow: hidden;
 }
 
 /* Hide spin-buttons in Chrome, Safari, Edge, and Opera */

--- a/apps/brewlog/src/index.css
+++ b/apps/brewlog/src/index.css
@@ -44,6 +44,14 @@ body {
   width: 100%;
 }
 
+/* Keep native date controls inside the form width in mobile WebViews. */
+input[type="date"] {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+}
+
 /* Hide spin-buttons in Chrome, Safari, Edge, and Opera */
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {


### PR DESCRIPTION
### Motivation
- モバイル WebView 環境で焙煎日／購入日／抽出日のネイティブ `date` 入力が右端で他の UI と合わずはみ出す問題を解消するため。

### Description
- `apps/brewlog/src/index.css` に `input[type="date"]` のスタイルを追加し、`box-sizing: border-box; width: 100%; min-width: 0; max-width: 100%;` を適用してフォーム幅内に収まるようにした。

### Testing
- `vp check --fix` を実行しフォーマット・lint は通過した。
- `vp test` を実行し（2 ファイル、30 テスト）すべて成功した。
- `pnpm run guard:changes` は Corepack が `pnpm` を取得する際にネットワーク/プロキシのエラーで失敗したため実行できなかった。

Close #11
------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a93fb5f2db48321a42ef4d4ef9c98b3)