### PR TITLE
cafelog: 提供温度のデフォルトを `hot` に設定

### DIFF
--- a/apps/cafelog/src/lib/cafeLogForm.test.ts
+++ b/apps/cafelog/src/lib/cafeLogForm.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { createCafeLogDefaults } from "./cafeLogForm";
+
+describe("createCafeLogDefaults", () => {
+  it("defaults the serving style to hot", () => {
+    expect(createCafeLogDefaults().servingStyle).toBe("hot");
+  });
+});

--- a/apps/cafelog/src/lib/cafeLogForm.ts
+++ b/apps/cafelog/src/lib/cafeLogForm.ts
@@ -70,7 +70,7 @@ export const createCafeLogDefaults = (): CafeLogFormValues => {
     process: "",
     roast: "",
     isBlend: false,
-    servingStyle: null,
+    servingStyle: "hot",
     rating: 3,
     price: "",
     visitDate: `${yyyy}-${mm}-${dd}`,


### PR DESCRIPTION
### Motivation
- 新規のカフェ記録フォームで `servingStyle` が `null` になっていたため、開いた時点でホットが選択されるようにデフォルトを `hot` に設定して初期状態を保証します。

### Description
- `createCafeLogDefaults` の `servingStyle` を `null` から `"hot"` に変更し、`apps/cafelog/src/lib/cafeLogForm.test.ts` を追加してデフォルトが `hot` であることを検証するユニットテストを追加しました。

### Testing
- 実行した自動テストは `vitest run apps/cafelog/src/lib/cafeLogForm.test.ts` があり 1 件のテストが成功し、`pnpm --filter cafelog check` は環境の Corepack/pnpm の取得で外部レジストリへのアクセスが 403 により失敗したため完了しませんでした。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a955d72bbb48321bb7b599084e710eb)