### PR TITLE
fix(brewlog): disable coffee type selection for bean version mode

### DIFF
--- a/apps/brewlog/src/components/forms/BeanFields.tsx
+++ b/apps/brewlog/src/components/forms/BeanFields.tsx
@@ -28,6 +28,7 @@ export const BeanFields = ({ form, isVersionMode }: BeanFieldsProps) => (
               value={field.state.value}
               onValueChange={field.handleChange}
               options={coffeeTypeOptions}
+              disabled={isVersionMode}
             />
           </div>
         )}

--- a/packages/ui/src/components/segment.tsx
+++ b/packages/ui/src/components/segment.tsx
@@ -12,6 +12,7 @@ export type SegmentProps<T extends string> = {
   readonly options: readonly SegmentOption<T>[];
   readonly ariaLabel: string;
   readonly className?: string;
+  readonly disabled?: boolean;
 };
 
 export function Segment<T extends string>({
@@ -20,6 +21,7 @@ export function Segment<T extends string>({
   options,
   ariaLabel,
   className,
+  disabled = false,
 }: SegmentProps<T>) {
   const name = useId();
 
@@ -27,6 +29,7 @@ export function Segment<T extends string>({
     <div
       role="radiogroup"
       aria-label={ariaLabel}
+      aria-disabled={disabled}
       className={cn("grid grid-flow-col auto-cols-fr gap-1 rounded-2xl bg-muted/10 p-1", className)}
     >
       {options.map((option) => {
@@ -36,10 +39,11 @@ export function Segment<T extends string>({
           <label
             key={option.value}
             className={cn(
-              "cursor-pointer rounded-xl px-3 py-2.5 text-center text-xs font-bold transition-all has-focus-visible:ring-2 has-focus-visible:ring-ring active:scale-[0.98]",
+              "rounded-xl px-3 py-2.5 text-center text-xs font-bold transition-all has-focus-visible:ring-2 has-focus-visible:ring-ring",
+              disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer active:scale-[0.98]",
               selected
                 ? "bg-surface text-primary shadow-sm"
-                : "text-muted hover:bg-surface/60 hover:text-primary",
+                : cn("text-muted", !disabled && "hover:bg-surface/60 hover:text-primary"),
             )}
           >
             <input
@@ -47,6 +51,7 @@ export function Segment<T extends string>({
               name={name}
               value={option.value}
               checked={selected}
+              disabled={disabled}
               onChange={() => onValueChange(option.value)}
               className="sr-only"
             />


### PR DESCRIPTION
### Motivation

- Prevent inconsistent coffee classification when adding a new version of an existing bean by making the coffee-type selector read-only in version mode.
- The shared `Segment` primitive previously had no `disabled` API, so disabling at call sites was not possible in a type-safe, accessible way.

### Description

- Add an optional `disabled?: boolean` prop to the shared component `packages/ui/src/components/segment.tsx` and implement `aria-disabled`, native `disabled` on the radio input, and visual/interaction styles for the disabled state.
- Pass `disabled={isVersionMode}` from `apps/brewlog/src/components/forms/BeanFields.tsx` so the coffee-type `Segment` cannot be changed when `isVersionMode` is true.
- Commit message: `fix(brewlog): disable coffee type for bean versions` (changes in `packages/ui/src/components/segment.tsx` and `apps/brewlog/src/components/forms/BeanFields.tsx`).

### Testing

- Type-check `packages/ui` with `./node_modules/.bin/tsc --noEmit` and `apps/brewlog` with `./node_modules/.bin/tsc --noEmit`, both succeeded.
- Unit tests with `./node_modules/.bin/vitest run` succeeded (30 tests passed).
- Lint/format check with `vp check --fix` / `../../node_modules/.bin/vp check --fix` completed formatting and reported no warnings for the checked files.
- Repository guard `pnpm run guard:changes` failed in this environment due to Corepack attempting to fetch `pnpm` (network/proxy to registry blocked), so the full pre-commit guard could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a997d3767588321945cb3fd43edf1e8)