### PR TITLE
feat(brewlog): improve bean list details

### DIFF
--- a/apps/brewlog/src/components/ui/RoastLevelIndicator.tsx
+++ b/apps/brewlog/src/components/ui/RoastLevelIndicator.tsx
@@ -4,6 +4,7 @@ import { getRoastLabel as getSharedRoastLabel } from "@yahatapp/coffee-reference
 interface RoastLevelIndicatorProps {
   level: number;
   className?: string;
+  showLabel?: boolean;
 }
 
 export const getRoastLabel = getSharedRoastLabel;
@@ -66,12 +67,15 @@ export const getRoastConfig = (level: number) => {
 export const RoastLevelIndicator: React.FC<RoastLevelIndicatorProps> = ({
   level,
   className = "",
+  showLabel = true,
 }) => {
   const config = getRoastConfig(level);
 
   return (
     <div
-      className={`inline-flex items-center space-x-1.5 py-1 px-2.5 rounded-full border ${config.bg} ${config.border} flex-shrink-0 transition-all duration-300 shadow-sm shadow-coffee-primary/2 hover:scale-[1.02] ${className}`}
+      className={`inline-flex items-center ${showLabel ? "space-x-1.5 py-1 px-2.5" : "p-1.5"} rounded-full border ${config.bg} ${config.border} flex-shrink-0 transition-all duration-300 shadow-sm shadow-coffee-primary/2 hover:scale-[1.02] ${className}`}
+      title={config.label}
+      aria-label={`焙煎度: ${config.label}`}
     >
       <span
         className="w-2.5 h-2.5 rounded-full flex-shrink-0"
@@ -80,7 +84,11 @@ export const RoastLevelIndicator: React.FC<RoastLevelIndicatorProps> = ({
           boxShadow: `0 1px 2px ${config.color}30, inset 0 -0.5px 1px rgba(0,0,0,0.15)`,
         }}
       />
-      <span className={`text-[10px] font-bold ${config.text} tracking-wider`}>{config.label}</span>
+      {showLabel && (
+        <span className={`text-[10px] font-bold ${config.text} tracking-wider`} aria-hidden="true">
+          {config.label}
+        </span>
+      )}
     </div>
   );
 };

--- a/apps/brewlog/src/pages/Beans/BeansList.tsx
+++ b/apps/brewlog/src/pages/Beans/BeansList.tsx
@@ -64,7 +64,7 @@ const BeansList = () => {
     return counts;
   }, [beansQuery.data, logsQuery.data]);
 
-  if (beansQuery.isPending || logsQuery.isPending) {
+  if (beansQuery.isPending) {
     return (
       <div className="flex justify-center items-center h-64">
         <Loader2 className="animate-spin text-coffee-primary" size={32} />
@@ -72,14 +72,11 @@ const BeansList = () => {
     );
   }
 
-  if (beansQuery.isError || logsQuery.isError) {
+  if (beansQuery.isError) {
     return (
       <div className="text-center p-8 text-coffee-secondary">
         <p>豆一覧の取得に失敗しました。</p>
-        <Button
-          className="mt-4 rounded-xl"
-          onClick={() => void Promise.all([beansQuery.refetch(), logsQuery.refetch()])}
-        >
+        <Button className="mt-4 rounded-xl" onClick={() => void beansQuery.refetch()}>
           再読み込み
         </Button>
       </div>
@@ -99,6 +96,23 @@ const BeansList = () => {
           <Plus size={16} className="mr-1" /> 追加
         </Button>
       </div>
+
+      {logsQuery.isError && (
+        <div
+          className="flex items-center justify-between gap-3 rounded-xl bg-coffee-secondary/10 px-4 py-3 text-xs text-coffee-secondary"
+          role="status"
+        >
+          <p>抽出回数を取得できませんでした。豆の管理は引き続き行えます。</p>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-auto shrink-0 px-2 py-1"
+            onClick={() => void logsQuery.refetch()}
+          >
+            再試行
+          </Button>
+        </div>
+      )}
 
       {groupedBeans.length === 0 ? (
         <Card className="border-dashed border-2">
@@ -159,7 +173,11 @@ const BeansList = () => {
                         </span>
                         <span className="inline-flex items-center gap-1 font-medium">
                           <Coffee size={13} aria-hidden="true" />
-                          {brewCount}回抽出
+                          {logsQuery.isPending
+                            ? "抽出回数を取得中"
+                            : logsQuery.isError
+                              ? "抽出回数未取得"
+                              : `${brewCount}回抽出`}
                         </span>
                         <span>
                           {displayDate

--- a/apps/brewlog/src/pages/Beans/BeansList.tsx
+++ b/apps/brewlog/src/pages/Beans/BeansList.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { Plus, Coffee, ChevronRight, Loader2, Pencil } from "lucide-react";
-import { beanQueries, type Bean } from "@/lib/queries";
+import { Plus, Coffee, ChevronRight, Loader2, Pencil, Sparkles } from "lucide-react";
+import { beanQueries, logQueries, type Bean } from "@/lib/queries";
 import { Button } from "../../components/ui/button";
 import { Card, CardContent } from "../../components/ui/card";
 import { OriginFlag } from "../../components/ui/OriginFlag";
@@ -20,10 +20,10 @@ interface BeanGroup {
 const BeansList = () => {
   const navigate = useNavigate();
   const beansQuery = useQuery(beanQueries.all());
+  const logsQuery = useQuery(logQueries.all());
   const [selectedGroup, setSelectedGroup] = useState<BeanGroup | null>(null);
 
   const beans = beansQuery.data ?? [];
-
   const activeBeans = beans.filter((bean) => !bean.isArchived);
 
   const groupedBeans = useMemo(() => {
@@ -52,7 +52,19 @@ const BeansList = () => {
       );
   }, [activeBeans]);
 
-  if (beansQuery.isPending) {
+  const brewCountByGroupId = useMemo(() => {
+    const counts = new Map<string, number>();
+    const groupIdByBeanId = new Map(
+      (beansQuery.data ?? []).map((bean) => [bean.id, bean.parentBeanId || bean.id] as const),
+    );
+    for (const log of logsQuery.data ?? []) {
+      const groupId = groupIdByBeanId.get(log.beanId);
+      if (groupId) counts.set(groupId, (counts.get(groupId) ?? 0) + 1);
+    }
+    return counts;
+  }, [beansQuery.data, logsQuery.data]);
+
+  if (beansQuery.isPending || logsQuery.isPending) {
     return (
       <div className="flex justify-center items-center h-64">
         <Loader2 className="animate-spin text-coffee-primary" size={32} />
@@ -60,11 +72,14 @@ const BeansList = () => {
     );
   }
 
-  if (beansQuery.isError) {
+  if (beansQuery.isError || logsQuery.isError) {
     return (
       <div className="text-center p-8 text-coffee-secondary">
         <p>豆一覧の取得に失敗しました。</p>
-        <Button className="mt-4 rounded-xl" onClick={() => void beansQuery.refetch()}>
+        <Button
+          className="mt-4 rounded-xl"
+          onClick={() => void Promise.all([beansQuery.refetch(), logsQuery.refetch()])}
+        >
           再読み込み
         </Button>
       </div>
@@ -101,15 +116,17 @@ const BeansList = () => {
       ) : (
         <div className="space-y-3">
           {groupedBeans.map((group) => {
-            const { latestBean, versionCount } = group;
+            const { latestBean } = group;
+            const brewCount = brewCountByGroupId.get(group.groupId) ?? 0;
+            const displayDate = latestBean.purchaseDate ?? latestBean.roastDate;
             return (
               <Card
                 key={group.groupId}
                 className="hover:border-coffee-primary/30 transition-colors cursor-pointer group"
                 onClick={() => setSelectedGroup(group)}
               >
-                <CardContent className="p-4 flex items-center justify-between">
-                  <div className="flex items-center space-x-4 flex-1 min-w-0">
+                <CardContent className="p-4 flex items-center gap-3">
+                  <div className="flex items-center flex-1 min-w-0 gap-3">
                     <div className="bg-coffee-background w-12 h-12 rounded-2xl flex items-center justify-center group-hover:bg-coffee-primary/10 transition-colors flex-shrink-0 overflow-hidden">
                       {(() => {
                         const countryCode = getCountryCode(latestBean.origin);
@@ -127,19 +144,27 @@ const BeansList = () => {
                         return <CoffeeBeansIcon size={24} className="text-coffee-primary" />;
                       })()}
                     </div>
-                    <div className="min-w-0 flex-1">
+                    <div className="min-w-0 flex-1 space-y-1.5">
                       <h3 className="font-bold text-coffee-text truncate">{latestBean.name}</h3>
-                      <div className="flex flex-wrap gap-2 mt-1">
-                        {versionCount > 0 && (
-                          <span className="text-[10px] text-coffee-primary bg-coffee-primary/10 px-2 py-0.5 rounded-full font-bold">
-                            {versionCount}バージョン
-                          </span>
-                        )}
-                        <span className="text-[10px] text-coffee-secondary bg-coffee-secondary/10 px-2 py-0.5 rounded-full truncate max-w-[120px]">
-                          最新:{" "}
-                          {latestBean.version ||
-                            latestBean.purchaseDate?.replace(/-/g, ".") ||
-                            "未設定"}
+                      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-coffee-secondary">
+                        <span
+                          className={`inline-flex items-center gap-1 font-medium ${
+                            latestBean.coffeeType === "specialty" ? "text-amber-700" : ""
+                          }`}
+                        >
+                          {latestBean.coffeeType === "specialty" && (
+                            <Sparkles size={13} className="text-amber-500" aria-hidden="true" />
+                          )}
+                          {latestBean.coffeeType === "specialty" ? "スペシャルティ" : "レギュラー"}
+                        </span>
+                        <span className="inline-flex items-center gap-1 font-medium">
+                          <Coffee size={13} aria-hidden="true" />
+                          {brewCount}回抽出
+                        </span>
+                        <span>
+                          {displayDate
+                            ? `${latestBean.purchaseDate ? "購入" : "焙煎"} ${displayDate.replace(/-/g, ".")}`
+                            : "日付未設定"}
                         </span>
                       </div>
                       <div className="flex flex-wrap gap-2 mt-1 hidden sm:flex">
@@ -162,8 +187,10 @@ const BeansList = () => {
                       </div>
                     </div>
                   </div>
-                  <div className="flex items-center space-x-3 ml-4 flex-shrink-0">
-                    {latestBean.roastLevel && <RoastLevelIndicator level={latestBean.roastLevel} />}
+                  <div className="flex items-center gap-1 flex-shrink-0">
+                    {latestBean.roastLevel && (
+                      <RoastLevelIndicator level={latestBean.roastLevel} showLabel={false} />
+                    )}
                     <div className="flex items-center space-x-1">
                       <button
                         onClick={(e) => {


### PR DESCRIPTION
### Motivation
- Make the beans list more informative and scannable by showing coffee type (specialty/regular), an aggregated brew count across versions, and by making the roast level readable by color only while preserving accessibility hints.
- Replace compact chips for date/version with a clearer caption-style date and allocate more horizontal space to bean names for better readability.
- Reduce visual clutter on the list while preserving the ability to open the bean group and add logs or new versions.

### Description
- Add a `showLabel?: boolean` prop to `RoastLevelIndicator` and expose `title`/`aria-label` so the indicator can be rendered compact (color-only) but remain accessible in the list (`apps/brewlog/src/components/ui/RoastLevelIndicator.tsx`).
- Fetch logs in `BeansList` and compute aggregated brew counts per bean group (including versions) to display total extract count on each card (`apps/brewlog/src/pages/Beans/BeansList.tsx`).
- Surface `coffeeType` as either "スペシャルティ" or "レギュラー" with a sparkle icon for specialty beans, remove the inline version chip, and show purchase/roast date as a caption-like field with a clear "未設定" fallback (`apps/brewlog/src/pages/Beans/BeansList.tsx`).
- Adjust card layout and tailwind classes so the name gets prioritized space and the roast indicator is shown in compact color-only mode on the list (`apps/brewlog/src/pages/Beans/BeansList.tsx`).

### Testing
- `vp check --fix` ran and formatting/lint checks passed after fixes applied. 
- `vp test` ran and all tests passed (2 files, 30 tests succeeded). 
- `vp build` completed successfully and produced the build artifacts. 
- Guard checks could not be fully exercised in this environment because `pnpm`/Corepack fetch failed behind a proxy and `betterleaks` was not available, so pre-commit secret checks were not executable here.

Close #28
------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9983bc3a988321ac2520013c9ea945)