### PR TITLE
feat(cafelog): コーヒー属性表示を整理するコンポーネントを追加

### DIFF
--- a/apps/cafelog/src/components/CoffeeAttributes.tsx
+++ b/apps/cafelog/src/components/CoffeeAttributes.tsx
@@ -1,0 +1,116 @@
+import { Bean, Flame, Layers3, MapPin, Snowflake, Sprout, ThermometerSun } from "lucide-react";
+import type { ComponentType } from "react";
+
+type CoffeeAttributesValue = {
+  origin?: string | null;
+  region?: string | null;
+  variety?: string | null;
+  farm?: string | null;
+  process?: string | null;
+  roast?: string | null;
+  isBlend?: boolean | null;
+  servingStyle?: string | null;
+};
+
+type AttributeGroup = {
+  label: string;
+  icon: ComponentType<{ className?: string; size?: number }>;
+  values: string[];
+};
+
+const getAttributeGroups = (coffee: CoffeeAttributesValue): AttributeGroup[] => [
+  {
+    label: "産地",
+    icon: MapPin,
+    values: [coffee.origin, coffee.region].filter((value): value is string => Boolean(value)),
+  },
+  {
+    label: "農園・品種",
+    icon: Sprout,
+    values: [coffee.farm, coffee.variety].filter((value): value is string => Boolean(value)),
+  },
+  {
+    label: "精製・焙煎",
+    icon: Flame,
+    values: [coffee.process, coffee.roast].filter((value): value is string => Boolean(value)),
+  },
+  {
+    label: "一杯のスタイル",
+    icon: coffee.servingStyle === "iced" ? Snowflake : ThermometerSun,
+    values: [
+      coffee.isBlend == null ? null : coffee.isBlend ? "ブレンド" : "シングルオリジン",
+      coffee.servingStyle === "hot" ? "ホット" : coffee.servingStyle === "iced" ? "アイス" : null,
+    ].filter((value): value is string => Boolean(value)),
+  },
+];
+
+export const CoffeeAttributes = ({
+  coffee,
+  compact = false,
+}: {
+  coffee: CoffeeAttributesValue;
+  compact?: boolean;
+}) => {
+  const groups = getAttributeGroups(coffee).filter(({ values }) => values.length > 0);
+
+  if (groups.length === 0) {
+    return compact ? null : (
+      <div className="flex items-center gap-2 rounded-xl bg-cafe-background/60 px-3 py-3 text-xs text-cafe-secondary">
+        <Bean aria-hidden="true" size={15} />
+        <span>豆の情報は登録されていません</span>
+      </div>
+    );
+  }
+
+  if (compact) {
+    return (
+      <dl className="mt-2 space-y-1.5" aria-label="コーヒーの属性">
+        {groups.map(({ label, icon: Icon, values }) => (
+          <div key={label} className="flex min-w-0 items-start gap-2 text-xs">
+            <dt className="flex w-5 shrink-0 justify-center pt-0.5 text-cafe-primary/70">
+              <Icon aria-hidden="true" size={13} />
+              <span className="sr-only">{label}</span>
+            </dt>
+            <dd className="min-w-0 break-words font-medium leading-relaxed text-cafe-secondary">
+              {values.join(" ・ ")}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    );
+  }
+
+  return (
+    <section aria-labelledby="coffee-attributes-heading" className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Layers3 aria-hidden="true" className="text-cafe-primary" size={16} />
+        <h4
+          id="coffee-attributes-heading"
+          className="text-xs font-bold tracking-wide text-cafe-text"
+        >
+          コーヒーの情報
+        </h4>
+      </div>
+      <dl className="divide-y divide-cafe-secondary/10 overflow-hidden rounded-xl border border-cafe-secondary/10 bg-cafe-background/35">
+        {groups.map(({ label, icon: Icon, values }) => (
+          <div key={label} className="grid grid-cols-[7rem_1fr] items-start gap-3 px-4 py-3">
+            <dt className="flex items-center gap-2 text-[11px] font-bold text-cafe-secondary">
+              <Icon aria-hidden="true" className="text-cafe-primary" size={14} />
+              {label}
+            </dt>
+            <dd className="flex flex-wrap justify-end gap-1.5 text-right">
+              {values.map((value) => (
+                <span
+                  key={value}
+                  className="rounded-full border border-cafe-secondary/15 bg-white px-2.5 py-1 text-xs font-semibold leading-none text-cafe-text shadow-xs"
+                >
+                  {value}
+                </span>
+              ))}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+};

--- a/apps/cafelog/src/pages/Home.tsx
+++ b/apps/cafelog/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { useLiff } from "@/hooks/useLiff";
 import { getErrorMessage } from "@/lib/errors";
 import { cafelogQueries } from "@/lib/queries";
+import { CoffeeAttributes } from "@/components/CoffeeAttributes";
 import {
   ArrowRight,
   Coffee,
@@ -13,39 +14,6 @@ import {
   MessageSquare,
   Loader2,
 } from "lucide-react";
-const formatCoffeeInfo = (log: {
-  origin?: string | null;
-  region?: string | null;
-  variety?: string | null;
-  farm?: string | null;
-  process?: string | null;
-  roast?: string | null;
-  isBlend?: boolean | null;
-  servingStyle?: string | null;
-}) => {
-  const parts = [];
-  if (log.origin) parts.push(log.origin);
-  if (log.region) parts.push(log.region);
-  if (log.farm) parts.push(log.farm);
-  if (log.variety) parts.push(log.variety);
-
-  let base = parts.join(" ");
-
-  const tags = [];
-  if (log.process) tags.push(log.process);
-  if (log.roast) tags.push(log.roast);
-  if (log.isBlend !== null && log.isBlend !== undefined) {
-    tags.push(log.isBlend ? "ブレンド" : "シングル");
-  }
-  if (log.servingStyle) tags.push(log.servingStyle === "hot" ? "ホット" : "アイス");
-
-  if (tags.length > 0) {
-    base += ` (${tags.join(" / ")})`;
-  }
-
-  return base.trim() || "";
-};
-
 const HomePage = () => {
   const { profile } = useLiff();
   const { data: logs = [], isPending: isLoading, error } = useQuery(cafelogQueries.logs());
@@ -167,11 +135,7 @@ const HomePage = () => {
                       <h4 className="break-words font-bold text-cafe-text text-sm leading-snug">
                         {log.cafeName}
                       </h4>
-                      {formatCoffeeInfo(log) && (
-                        <p className="break-words text-[10px] text-cafe-secondary font-medium mt-0.5">
-                          {formatCoffeeInfo(log)}
-                        </p>
-                      )}
+                      <CoffeeAttributes coffee={log} compact />
                     </div>
                     {log.rating && (
                       <div className="flex shrink-0 items-center space-x-1">

--- a/apps/cafelog/src/pages/LogDetail.tsx
+++ b/apps/cafelog/src/pages/LogDetail.tsx
@@ -13,6 +13,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { CafeLogForm } from "@/components/CafeLogForm";
+import { CoffeeAttributes } from "@/components/CoffeeAttributes";
 import { LogImages } from "@/components/LogImages";
 import type { CafeLogFormValues } from "@/lib/cafeLogForm";
 import { getErrorMessage } from "@/lib/errors";
@@ -23,27 +24,6 @@ import {
   updateLog,
   uploadLogImages,
 } from "@/lib/queries";
-
-const formatCoffeeInfo = (log: {
-  origin?: string | null;
-  region?: string | null;
-  variety?: string | null;
-  farm?: string | null;
-  process?: string | null;
-  roast?: string | null;
-  isBlend?: boolean | null;
-  servingStyle?: string | null;
-}) => {
-  const parts = [log.origin, log.region, log.farm, log.variety].filter(Boolean);
-  const tags = [
-    log.process,
-    log.roast,
-    log.isBlend == null ? null : log.isBlend ? "ブレンド" : "シングル",
-    log.servingStyle === "hot" ? "ホット" : log.servingStyle === "iced" ? "アイス" : null,
-  ].filter(Boolean);
-  const base = parts.join(" ");
-  return tags.length ? `${base} (${tags.join(" / ")})`.trim() : base || "豆の詳細情報なし";
-};
 
 const toFormValues = (log: LogResponse): CafeLogFormValues => ({
   cafeName: log.cafeName,
@@ -229,8 +209,8 @@ const LogDetailPage = () => {
           <div className="space-y-1">
             <h4 className="text-red-700 font-bold text-sm">記録を削除しますか？</h4>
             <p className="text-xs text-red-600 leading-relaxed">
-              この操作は取り消せません。&ldquo;{log.cafeName} ({formatCoffeeInfo(log)}
-              )&rdquo;の記録を本当に削除してもよろしいですか？
+              この操作は取り消せません。&ldquo;{log.cafeName}
+              &rdquo;の記録を本当に削除してもよろしいですか？
             </p>
           </div>
           <div className="flex space-x-3">
@@ -285,9 +265,10 @@ const LogDetailPage = () => {
                   <ExternalLink size={12} className="shrink-0" />
                 </a>
               )}
-              <p className="text-xs text-cafe-secondary break-words">{formatCoffeeInfo(log)}</p>
             </div>
           </div>
+
+          <CoffeeAttributes coffee={log} />
 
           <div className="grid grid-cols-2 gap-4 border-t border-b border-cafe-secondary/10 py-5">
             <div className="space-y-1">

--- a/apps/cafelog/src/pages/Logs.tsx
+++ b/apps/cafelog/src/pages/Logs.tsx
@@ -3,38 +3,7 @@ import { Link } from "react-router-dom";
 import { getErrorMessage } from "@/lib/errors";
 import { cafelogQueries } from "@/lib/queries";
 import { ClipboardList, Plus, Star, Calendar, MessageSquare, Loader2 } from "lucide-react";
-const formatCoffeeInfo = (log: {
-  origin?: string | null;
-  region?: string | null;
-  variety?: string | null;
-  farm?: string | null;
-  process?: string | null;
-  roast?: string | null;
-  isBlend?: boolean | null;
-  servingStyle?: string | null;
-}) => {
-  const parts = [];
-  if (log.origin) parts.push(log.origin);
-  if (log.region) parts.push(log.region);
-  if (log.farm) parts.push(log.farm);
-  if (log.variety) parts.push(log.variety);
-
-  let base = parts.join(" ");
-
-  const tags = [];
-  if (log.process) tags.push(log.process);
-  if (log.roast) tags.push(log.roast);
-  if (log.isBlend !== null && log.isBlend !== undefined) {
-    tags.push(log.isBlend ? "ブレンド" : "シングル");
-  }
-  if (log.servingStyle) tags.push(log.servingStyle === "hot" ? "ホット" : "アイス");
-
-  if (tags.length > 0) {
-    base += ` (${tags.join(" / ")})`;
-  }
-
-  return base.trim() || "";
-};
+import { CoffeeAttributes } from "@/components/CoffeeAttributes";
 
 const LogsPage = () => {
   const { data: logs = [], isPending: isLoading, error, refetch } = useQuery(cafelogQueries.logs());
@@ -157,11 +126,7 @@ const LogsPage = () => {
                     <h3 className="break-words font-bold text-cafe-text text-base leading-snug">
                       {log.cafeName}
                     </h3>
-                    {formatCoffeeInfo(log) && (
-                      <p className="break-words text-xs text-cafe-secondary font-medium mt-0.5">
-                        {formatCoffeeInfo(log)}
-                      </p>
-                    )}
+                    <CoffeeAttributes coffee={log} compact />
                   </div>
                   {log.rating && (
                     <div className="flex shrink-0 items-center space-x-1.5">


### PR DESCRIPTION
### Motivation

- 記録一覧・詳細のコーヒー属性表示が一続きで読みづらかったため、意味ごとに整理して視認性を向上させるための変更です。

### Description

- 新しい共通コンポーネント `CoffeeAttributes` を追加し、産地／農園・品種／精製・焙煎／一杯のスタイルのグループ化とアイコン表示を実装しました（`apps/cafelog/src/components/CoffeeAttributes.tsx`）。
- `Home`, `Logs`, `LogDetail` の表示を `CoffeeAttributes` に置き換え、省スペース表示（`compact`）と詳細表示の両方に対応しました（`apps/cafelog/src/pages/Home.tsx`、`apps/cafelog/src/pages/Logs.tsx`、`apps/cafelog/src/pages/LogDetail.tsx`）。
- 未登録時の案内表示や、ラベル＋チップ形式での視覚的な整理を行い、既存の文字列結合ロジックを削除しました。

### Testing

- `vp check --fix` を実行してフォーマットの修正を適用し、その後の `vp check` は成功しました。
- `vp test` は該当アプリで実行し、テストは合計15件すべて成功しました。
- `vp build` によるビルドは正常に完了しました。
- `pnpm --filter cafelog check/test/build` は Corepack の pnpm ダウンロードがネットワーク制限（プロキシ 403）で失敗したため実行できませんでしたが、プロジェクトに含まれる Vite+ バイナリでのチェック／テスト／ビルドは代替で成功しています。
- モバイル幅のレンダリング確認として自動でスクリーンショットを生成し画像が作成されることを確認しました（`/tmp/cafelog-attributes.png` が存在）。

Close #31
------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9985e6e1588321a01444e61517c3ba)