### PR TITLE
feat(brewlog): 豆の詳細画面と抽出記録からの導線を追加

### DIFF
--- a/apps/brewlog/src/App.tsx
+++ b/apps/brewlog/src/App.tsx
@@ -6,6 +6,7 @@ import { LiffProvider, useLiff } from "./hooks/useLiff";
 import HomePage from "./pages/Home";
 import BeansPage from "./pages/Beans/BeansList";
 import AddBeanPage from "./pages/Beans/AddBean";
+import BeanDetailPage from "./pages/Beans/BeanDetail";
 import EditBeanPage from "./pages/Beans/EditBean";
 import LogsPage from "./pages/Logs/LogsList";
 import AddLogPage from "./pages/Logs/AddLog";
@@ -114,6 +115,7 @@ const AppContent = () => {
           <Route path="/" element={<HomePage />} />
           <Route path="/beans" element={<BeansPage />} />
           <Route path="/beans/new" element={<AddBeanPage />} />
+          <Route path="/beans/:id" element={<BeanDetailPage />} />
           <Route path="/beans/:id/edit" element={<EditBeanPage />} />
           <Route path="/logs" element={<LogsPage />} />
           <Route path="/logs/new" element={<AddLogPage />} />

--- a/apps/brewlog/src/pages/Beans/BeanDetail.tsx
+++ b/apps/brewlog/src/pages/Beans/BeanDetail.tsx
@@ -1,6 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
-import { ArrowLeft, Coffee, Edit2, Loader2, MapPin, NotebookText, Store } from "lucide-react";
+import {
+  ArrowLeft,
+  Coffee,
+  CopyPlus,
+  Edit2,
+  Loader2,
+  MapPin,
+  NotebookText,
+  Store,
+} from "lucide-react";
 import { beanQueries } from "@/lib/queries";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -114,19 +123,28 @@ const BeanDetail = () => {
         </CardContent>
       </Card>
 
-      <div className="grid grid-cols-2 gap-3">
+      <div className="space-y-3">
+        <div className="grid grid-cols-2 gap-3">
+          <Button
+            variant="outline"
+            className="h-12 rounded-2xl border-coffee-primary/30"
+            onClick={() => navigate(`/beans/${bean.id}/edit`)}
+          >
+            <Edit2 size={17} className="mr-2" /> 編集する
+          </Button>
+          <Button
+            className="h-12 rounded-2xl shadow-md"
+            onClick={() => navigate(`/logs/new?beanId=${bean.id}`)}
+          >
+            <Coffee size={18} className="mr-2" /> 淹れる
+          </Button>
+        </div>
         <Button
           variant="outline"
-          className="h-12 rounded-2xl border-coffee-primary/30"
-          onClick={() => navigate(`/beans/${bean.id}/edit`)}
+          className="h-12 w-full rounded-2xl border-coffee-primary/30"
+          onClick={() => navigate(`/beans/new?parentBeanId=${bean.parentBeanId ?? bean.id}`)}
         >
-          <Edit2 size={17} className="mr-2" /> 編集する
-        </Button>
-        <Button
-          className="h-12 rounded-2xl shadow-md"
-          onClick={() => navigate(`/logs/new?beanId=${bean.id}`)}
-        >
-          <Coffee size={18} className="mr-2" /> 淹れる
+          <CopyPlus size={17} className="mr-2" /> 同じ豆の新しいバージョンを追加する
         </Button>
       </div>
     </div>

--- a/apps/brewlog/src/pages/Beans/BeanDetail.tsx
+++ b/apps/brewlog/src/pages/Beans/BeanDetail.tsx
@@ -1,0 +1,136 @@
+import { useQuery } from "@tanstack/react-query";
+import { useNavigate, useParams } from "react-router-dom";
+import { ArrowLeft, Coffee, Edit2, Loader2, MapPin, NotebookText, Store } from "lucide-react";
+import { beanQueries } from "@/lib/queries";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { OriginFlag } from "@/components/ui/OriginFlag";
+import { RoastLevelIndicator } from "@/components/ui/RoastLevelIndicator";
+
+const formatDate = (date: string | null) => date?.replaceAll("-", ".") || "未設定";
+
+const DetailRow = ({ label, value }: { label: string; value: React.ReactNode }) => (
+  <div className="flex items-start justify-between gap-4 border-b border-coffee-secondary/10 py-3 last:border-0">
+    <dt className="shrink-0 text-sm text-coffee-secondary">{label}</dt>
+    <dd className="text-right text-sm font-semibold text-coffee-text">{value || "未設定"}</dd>
+  </div>
+);
+
+const BeanDetail = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const beanQuery = useQuery(beanQueries.detail(id ?? ""));
+
+  if (beanQuery.isPending) {
+    return (
+      <div className="flex h-64 items-center justify-center" role="status">
+        <Loader2 className="animate-spin text-coffee-primary" size={32} />
+        <span className="sr-only">豆の詳細を読み込み中</span>
+      </div>
+    );
+  }
+
+  if (beanQuery.isError || !beanQuery.data) {
+    return (
+      <div className="p-8 text-center text-coffee-secondary">
+        <p>豆の詳細を取得できませんでした。</p>
+        <Button className="mt-4 rounded-xl" onClick={() => void beanQuery.refetch()}>
+          再読み込み
+        </Button>
+      </div>
+    );
+  }
+
+  const bean = beanQuery.data;
+
+  return (
+    <div className="animate-in space-y-5 fade-in slide-in-from-bottom-4 duration-500">
+      <div className="flex items-center gap-2">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => navigate("/beans")}
+          className="rounded-full"
+        >
+          <ArrowLeft size={20} />
+          <span className="sr-only">豆一覧へ戻る</span>
+        </Button>
+        <h2 className="text-xl font-bold text-coffee-primary">豆の詳細</h2>
+      </div>
+
+      <Card className="overflow-hidden border-2 border-coffee-primary/10 shadow-md">
+        <div className="bg-coffee-primary/5 p-5">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-xs font-bold text-coffee-secondary">
+                {bean.coffeeType === "specialty" ? "スペシャルティコーヒー" : "レギュラーコーヒー"}
+              </p>
+              <h3 className="mt-1 break-words text-2xl font-bold text-coffee-primary">
+                {bean.name}
+              </h3>
+              {bean.version && <p className="mt-1 text-sm text-coffee-secondary">{bean.version}</p>}
+            </div>
+            {bean.roastLevel && <RoastLevelIndicator level={bean.roastLevel} />}
+          </div>
+          {bean.origin && (
+            <div className="mt-4 flex items-center gap-2 text-sm font-medium text-coffee-secondary">
+              <OriginFlag origin={bean.origin} size={18} />
+              <MapPin size={14} aria-hidden="true" />
+              <span>{bean.origin}</span>
+            </div>
+          )}
+        </div>
+
+        <CardContent className="space-y-5 p-5">
+          <section aria-labelledby="bean-purchase-heading">
+            <h4
+              id="bean-purchase-heading"
+              className="flex items-center gap-2 text-sm font-bold text-coffee-primary"
+            >
+              <Store size={16} aria-hidden="true" /> 購入・焙煎情報
+            </h4>
+            <dl className="mt-2">
+              <DetailRow label="購入店" value={bean.purchaseStore} />
+              <DetailRow label="購入日" value={formatDate(bean.purchaseDate)} />
+              <DetailRow label="焙煎日" value={formatDate(bean.roastDate)} />
+              <DetailRow label="精製方法" value={bean.processMethod} />
+            </dl>
+          </section>
+
+          <section
+            className="border-t border-coffee-secondary/10 pt-5"
+            aria-labelledby="bean-note-heading"
+          >
+            <h4
+              id="bean-note-heading"
+              className="flex items-center gap-2 text-sm font-bold text-coffee-primary"
+            >
+              <NotebookText size={16} aria-hidden="true" /> メモ
+            </h4>
+            <p className="mt-3 whitespace-pre-wrap rounded-2xl bg-coffee-background/60 p-4 text-sm leading-6 text-coffee-text">
+              {bean.note || "メモはありません。"}
+            </p>
+          </section>
+        </CardContent>
+      </Card>
+
+      <div className="grid grid-cols-2 gap-3">
+        <Button
+          variant="outline"
+          className="h-12 rounded-2xl border-coffee-primary/30"
+          onClick={() => navigate(`/beans/${bean.id}/edit`)}
+        >
+          <Edit2 size={17} className="mr-2" /> 編集する
+        </Button>
+        <Button
+          className="h-12 rounded-2xl shadow-md"
+          onClick={() => navigate(`/logs/new?beanId=${bean.id}`)}
+        >
+          <Coffee size={18} className="mr-2" /> 淹れる
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default BeanDetail;

--- a/apps/brewlog/src/pages/Beans/BeansList.tsx
+++ b/apps/brewlog/src/pages/Beans/BeansList.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { Plus, Coffee, ChevronRight, Loader2, Pencil, Sparkles } from "lucide-react";
@@ -10,18 +10,10 @@ import { getCountryCode } from "@/utils/flag";
 import { CoffeeBeansIcon } from "../../components/ui/CoffeeBeansIcon";
 import { getRoastConfig, getRoastGradient } from "../../components/ui/RoastLevelIndicator";
 
-interface BeanGroup {
-  groupId: string;
-  latestBean: Bean;
-  allBeans: Bean[];
-  versionCount: number;
-}
-
 const BeansList = () => {
   const navigate = useNavigate();
   const beansQuery = useQuery(beanQueries.all());
   const logsQuery = useQuery(logQueries.all());
-  const [selectedGroup, setSelectedGroup] = useState<BeanGroup | null>(null);
 
   const beans = beansQuery.data ?? [];
   const activeBeans = beans.filter((bean) => !bean.isArchived);
@@ -42,8 +34,6 @@ const BeansList = () => {
         return {
           groupId,
           latestBean: sorted[0],
-          allBeans: sorted,
-          versionCount: sorted.length,
         };
       })
       .toSorted(
@@ -145,7 +135,15 @@ const BeansList = () => {
                     ? { backgroundImage: getRoastGradient(latestBean.roastLevel) }
                     : undefined
                 }
-                onClick={() => setSelectedGroup(group)}
+                onClick={() => navigate(`/beans/${latestBean.id}`)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    void navigate(`/beans/${latestBean.id}`);
+                  }
+                }}
+                role="link"
+                tabIndex={0}
               >
                 <CardContent className="p-4 flex items-center gap-3">
                   {roastConfig && <span className="sr-only">焙煎度: {roastConfig.label}</span>}
@@ -234,57 +232,6 @@ const BeansList = () => {
               </Card>
             );
           })}
-        </div>
-      )}
-
-      {selectedGroup && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 animate-in fade-in"
-          onClick={() => setSelectedGroup(null)}
-        >
-          <Card
-            className="w-full max-w-sm overflow-hidden shadow-2xl"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="p-4 bg-coffee-primary/5 border-b border-coffee-primary/10">
-              <h3 className="font-bold text-coffee-primary text-lg">
-                {selectedGroup.latestBean.name}
-              </h3>
-              <p className="text-sm text-coffee-secondary mt-1">
-                最新バージョン:{" "}
-                {selectedGroup.latestBean.version ||
-                  selectedGroup.latestBean.purchaseDate?.replace(/-/g, ".") ||
-                  "未設定"}
-              </p>
-            </div>
-            <div className="p-4 space-y-3">
-              <Button
-                className="w-full justify-start h-12 rounded-xl"
-                onClick={() => navigate(`/logs/new?beanId=${selectedGroup.latestBean.id}`)}
-              >
-                <Coffee size={18} className="mr-3" />
-                この豆で抽出記録をつける
-              </Button>
-              <Button
-                variant="outline"
-                className="w-full justify-start h-12 rounded-xl border-coffee-primary/20 hover:bg-coffee-primary/5"
-                onClick={() => navigate(`/beans/new?parentBeanId=${selectedGroup.groupId}`)}
-              >
-                <Plus size={18} className="mr-3 text-coffee-primary" />
-                同じ豆の新しいバージョン(購入)を追加する
-              </Button>
-            </div>
-            <div className="p-3 bg-gray-50 border-t border-gray-100 flex justify-end">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => setSelectedGroup(null)}
-                className="rounded-lg"
-              >
-                キャンセル
-              </Button>
-            </div>
-          </Card>
         </div>
       )}
     </div>

--- a/apps/brewlog/src/pages/Logs/LogDetail.tsx
+++ b/apps/brewlog/src/pages/Logs/LogDetail.tsx
@@ -11,6 +11,7 @@ import {
   User,
   Info,
   Check,
+  ChevronRight,
 } from "lucide-react";
 import { logQueries, type BrewLog, type BrewLogResponse } from "@/lib/queries";
 import { Button, cn } from "../../components/ui/button";
@@ -121,16 +122,21 @@ const LogDetail = () => {
             コーヒー豆
           </span>
           <div className="flex justify-between items-center mt-1">
-            <div>
+            <button
+              type="button"
+              onClick={() => navigate(`/beans/${log.bean.id}`)}
+              className="group min-w-0 rounded-xl -m-2 p-2 text-left transition-colors hover:bg-coffee-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coffee-primary"
+              aria-label={`${log.bean.name}の詳細を見る`}
+            >
               <h3 className="text-lg font-bold text-coffee-primary leading-tight">
                 {log.bean.name}
-                {log.bean.version && (
-                  <span className="text-sm font-normal text-coffee-secondary ml-1.5">
-                    ({log.bean.version})
-                  </span>
-                )}
+                <ChevronRight
+                  size={16}
+                  className="ml-1 inline transition-transform group-hover:translate-x-0.5"
+                  aria-hidden="true"
+                />
               </h3>
-              <div className="flex flex-col items-start gap-y-1 mt-1.5">
+              <div className="mt-1.5">
                 {log.bean.origin && (
                   <div className="flex items-center gap-1.5">
                     <span className="text-xs text-coffee-secondary">産地:</span>
@@ -140,16 +146,8 @@ const LogDetail = () => {
                     </span>
                   </div>
                 )}
-                {log.bean.processMethod && (
-                  <div className="flex items-center gap-1.5">
-                    <span className="text-xs text-coffee-secondary">精製方法:</span>
-                    <span className="text-xs text-coffee-secondary font-medium">
-                      {log.bean.processMethod}
-                    </span>
-                  </div>
-                )}
               </div>
-            </div>
+            </button>
             <div className="flex flex-col items-end gap-1.5 ml-4">
               {log.rating && (
                 <div className="flex items-center bg-yellow-400/10 border border-yellow-400/25 px-2.5 py-1 rounded-xl">


### PR DESCRIPTION
### Motivation
- 豆一覧や抽出記録から個々の豆情報を詳しく見られるようにして、編集や抽出記録作成への導線を用意するため。

### Description
- ルーティングを追加して `/beans/:id` に豆詳細ページを実装し、`apps/brewlog/src/pages/Beans/BeanDetail.tsx` を追加した。 
- 豆一覧のカードクリックで詳細ページへ遷移するようにし、キーボード操作とアクセシビリティ属性を追加した（`apps/brewlog/src/pages/Beans/BeansList.tsx` の更新）。
- 抽出記録詳細の豆表示を名前・産地中心に整理し、豆名から詳細ページへ遷移するボタンを追加した（`apps/brewlog/src/pages/Logs/LogDetail.tsx` の更新）。
- ルート登録を `apps/brewlog/src/App.tsx` に追加し、詳細画面に「編集する」と「淹れる」アクションを配置して既存コンポーネントを再利用した（`RoastLevelIndicator` / `OriginFlag` / UI ボタン等）。

### Testing
- 実行したチェックで `vp check --fix` は問題なく通過（フォーマットとリンティング修正を適用）。
- `vp test` は 2 ファイル、合計 30 テストがすべて成功しました。 
- `vp build` によりビルドが正常に完了しました。 
- 環境依存で `pnpm --filter brewlog check:fix` は Corepack が `pnpm` を取得する際のネットワーク/プロキシ制限により失敗し、また `./scripts/guard-changes.sh` は環境に `betterleaks` が無いため完走できませんでした（個別の `vp` ツールで代替検証済み）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9bd0b881f0832194fd5c26c69a31c5)