### PR TITLE
cafelog: 記録に都道府県フィールドとセレクトボックスを追加

### DIFF
--- a/apps/cafelog/db/migrations/0009_unknown_arclight.sql
+++ b/apps/cafelog/db/migrations/0009_unknown_arclight.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "cafelog"."cafe_logs" ADD COLUMN "prefecture" text;

--- a/apps/cafelog/db/migrations/meta/0009_snapshot.json
+++ b/apps/cafelog/db/migrations/meta/0009_snapshot.json
@@ -1,0 +1,294 @@
+{
+  "id": "4c01792e-553f-4c98-a8ec-4512ec8f6f56",
+  "prevId": "817b7429-0142-4c56-b262-d668619d1b0b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "cafelog.cafe_log_images": {
+      "name": "cafe_log_images",
+      "schema": "cafelog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "cafe_log_id": {
+          "name": "cafe_log_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cafe_log_images_log_position_unique": {
+          "name": "cafe_log_images_log_position_unique",
+          "columns": [
+            {
+              "expression": "cafe_log_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cafe_log_images_cafe_log_id_cafe_logs_id_fk": {
+          "name": "cafe_log_images_cafe_log_id_cafe_logs_id_fk",
+          "tableFrom": "cafe_log_images",
+          "tableTo": "cafe_logs",
+          "schemaTo": "cafelog",
+          "columnsFrom": ["cafe_log_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cafe_log_images_object_key_unique": {
+          "name": "cafe_log_images_object_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["object_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "cafe_log_images_position_range": {
+          "name": "cafe_log_images_position_range",
+          "value": "\"cafelog\".\"cafe_log_images\".\"position\" >= 0 AND \"cafelog\".\"cafe_log_images\".\"position\" < 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "cafelog.cafe_logs": {
+      "name": "cafe_logs",
+      "schema": "cafelog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cafe_name": {
+          "name": "cafe_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cafe_url": {
+          "name": "cafe_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefecture": {
+          "name": "prefecture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variety": {
+          "name": "variety",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "farm": {
+          "name": "farm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "process": {
+          "name": "process",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roast": {
+          "name": "roast",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_blend": {
+          "name": "is_blend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serving_style": {
+          "name": "serving_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visit_date": {
+          "name": "visit_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cafe_logs_user_id_profiles_line_user_id_fk": {
+          "name": "cafe_logs_user_id_profiles_line_user_id_fk",
+          "tableFrom": "cafe_logs",
+          "tableTo": "profiles",
+          "schemaTo": "cafelog",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["line_user_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "cafelog.profiles": {
+      "name": "profiles",
+      "schema": "cafelog",
+      "columns": {
+        "line_user_id": {
+          "name": "line_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "cafelog": "cafelog"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/cafelog/db/migrations/meta/_journal.json
+++ b/apps/cafelog/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1787445205685,
       "tag": "0008_massive_multiple_man",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1788530311871,
+      "tag": "0009_unknown_arclight",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/cafelog/db/schema.ts
+++ b/apps/cafelog/db/schema.ts
@@ -37,6 +37,7 @@ export const cafeLogs = cafelogSchema.table("cafe_logs", {
     .references(() => profiles.lineUserId),
   cafeName: text("cafe_name").notNull(),
   cafeUrl: text("cafe_url"),
+  prefecture: text("prefecture"),
   origin: text("origin"),
   region: text("region"),
   variety: text("variety"),

--- a/apps/cafelog/src/api/index.ts
+++ b/apps/cafelog/src/api/index.ts
@@ -6,6 +6,7 @@ import { profiles, cafeLogs, cafeLogImages } from "../../db/schema";
 import { and, asc, eq, desc } from "drizzle-orm";
 import { z } from "zod";
 import { HTTPException } from "hono/http-exception";
+import { PREFECTURES } from "@/lib/prefectures";
 
 const initSchema = z.object({
   displayName: z.string(),
@@ -17,10 +18,12 @@ const cafeUrlSchema = z.url().refine((url) => ["http:", "https:"].includes(new U
 });
 
 const servingStyleSchema = z.enum(["hot", "iced"]);
+const prefectureSchema = z.enum(PREFECTURES);
 
 const createLogSchema = z.object({
   cafeName: z.string().min(1),
   cafeUrl: cafeUrlSchema.optional().nullable(),
+  prefecture: prefectureSchema.optional().nullable(),
   origin: z.string().optional().nullable(),
   region: z.string().optional().nullable(),
   variety: z.string().optional().nullable(),
@@ -38,6 +41,7 @@ const createLogSchema = z.object({
 const updateLogSchema = z.object({
   cafeName: z.string().min(1).optional(),
   cafeUrl: cafeUrlSchema.optional().nullable(),
+  prefecture: prefectureSchema.optional().nullable(),
   origin: z.string().optional().nullable(),
   region: z.string().optional().nullable(),
   variety: z.string().optional().nullable(),

--- a/apps/cafelog/src/components/CafeLogForm.tsx
+++ b/apps/cafelog/src/components/CafeLogForm.tsx
@@ -5,6 +5,7 @@ import { ImagePicker } from "@/components/ImagePicker";
 import { ProcessField } from "@/components/ProcessField";
 import { Segment } from "@/components/Segment";
 import { cafeLogFormSchema, type CafeLogFormValues } from "@/lib/cafeLogForm";
+import { FREQUENT_PREFECTURES, PREFECTURE_GROUPS } from "@/lib/prefectures";
 
 type CafeLogFormProps = {
   defaultValues: CafeLogFormValues;
@@ -109,6 +110,44 @@ export const CafeLogForm = ({
               {errorMessage(field.state.meta.errors) && (
                 <p className="mt-1 text-xs text-red-600">{errorMessage(field.state.meta.errors)}</p>
               )}
+            </div>
+          )}
+        </form.Field>
+
+        <form.Field name="prefecture">
+          {(field) => (
+            <div>
+              <label
+                htmlFor="cafe-prefecture"
+                className="text-xs font-bold text-cafe-text block mb-1.5"
+              >
+                都道府県
+              </label>
+              <select
+                id="cafe-prefecture"
+                value={field.state.value}
+                onChange={(event) => field.handleChange(event.target.value)}
+                onBlur={field.handleBlur}
+                className="w-full bg-cafe-background border border-cafe-secondary/20 rounded-xl px-4 py-3 text-sm text-cafe-text focus:outline-none focus:ring-2 focus:ring-cafe-primary/10 focus:border-cafe-primary/60 transition-all"
+              >
+                <option value="">選択してください</option>
+                <optgroup label="よく行く都道府県">
+                  {FREQUENT_PREFECTURES.map((prefecture) => (
+                    <option key={prefecture} value={prefecture}>
+                      {prefecture}
+                    </option>
+                  ))}
+                </optgroup>
+                {PREFECTURE_GROUPS.map((group) => (
+                  <optgroup key={group.label} label={group.label}>
+                    {group.prefectures.map((prefecture) => (
+                      <option key={prefecture} value={prefecture}>
+                        {prefecture}
+                      </option>
+                    ))}
+                  </optgroup>
+                ))}
+              </select>
             </div>
           )}
         </form.Field>

--- a/apps/cafelog/src/lib/cafeLogForm.test.ts
+++ b/apps/cafelog/src/lib/cafeLogForm.test.ts
@@ -1,8 +1,42 @@
 import { describe, expect, it } from "vitest";
-import { createCafeLogDefaults } from "./cafeLogForm";
+import { cafeLogFormSchema, createCafeLogDefaults, toCafeLogPayload } from "./cafeLogForm";
+import { FREQUENT_PREFECTURES, PREFECTURES } from "./prefectures";
 
 describe("createCafeLogDefaults", () => {
   it("defaults the serving style to hot", () => {
     expect(createCafeLogDefaults().servingStyle).toBe("hot");
+  });
+
+  it("defaults the prefecture to unselected", () => {
+    expect(createCafeLogDefaults().prefecture).toBe("");
+  });
+
+  it("converts an unselected prefecture to null", () => {
+    expect(toCafeLogPayload(createCafeLogDefaults()).prefecture).toBeNull();
+  });
+
+  it("accepts a Japanese prefecture and rejects an unknown value", () => {
+    expect(
+      cafeLogFormSchema.safeParse({
+        ...createCafeLogDefaults(),
+        cafeName: "テスト店",
+        prefecture: "山口県",
+      }).success,
+    ).toBe(true);
+    expect(
+      cafeLogFormSchema.safeParse({
+        ...createCafeLogDefaults(),
+        cafeName: "テスト店",
+        prefecture: "不明",
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("PREFECTURES", () => {
+  it("lists the five frequent prefectures first and includes all 47 exactly once", () => {
+    expect(PREFECTURES.slice(0, 5)).toEqual(FREQUENT_PREFECTURES);
+    expect(PREFECTURES).toHaveLength(47);
+    expect(new Set(PREFECTURES)).toHaveLength(47);
   });
 });

--- a/apps/cafelog/src/lib/cafeLogForm.ts
+++ b/apps/cafelog/src/lib/cafeLogForm.ts
@@ -1,9 +1,11 @@
 import { z } from "zod";
 import type { SelectedImage } from "@/components/ImagePicker";
+import { PREFECTURES } from "@/lib/prefectures";
 
 export type CafeLogFormValues = {
   cafeName: string;
   cafeUrl: string;
+  prefecture: string;
   origin: string;
   region: string;
   variety: string;
@@ -39,6 +41,7 @@ const optionalPriceSchema = z
 export const cafeLogFormSchema = z.object({
   cafeName: z.string().trim().min(1, "店舗名は必須項目です。"),
   cafeUrl: optionalUrlSchema,
+  prefecture: z.union([z.literal(""), z.enum(PREFECTURES)]),
   origin: z.string(),
   region: z.string(),
   variety: z.string(),
@@ -63,6 +66,7 @@ export const createCafeLogDefaults = (): CafeLogFormValues => {
   return {
     cafeName: "",
     cafeUrl: "",
+    prefecture: "",
     origin: "",
     region: "",
     variety: "",
@@ -82,6 +86,7 @@ export const createCafeLogDefaults = (): CafeLogFormValues => {
 export const toCafeLogPayload = (values: CafeLogFormValues) => ({
   cafeName: values.cafeName.trim(),
   cafeUrl: values.cafeUrl.trim() || null,
+  prefecture: values.prefecture || null,
   origin: values.origin.trim() || null,
   region: values.region.trim() || null,
   variety: values.variety.trim() || null,

--- a/apps/cafelog/src/lib/prefectures.ts
+++ b/apps/cafelog/src/lib/prefectures.ts
@@ -1,0 +1,27 @@
+export const FREQUENT_PREFECTURES = ["東京都", "愛知県", "大阪府", "京都府", "山口県"] as const;
+
+export const PREFECTURE_GROUPS = [
+  {
+    label: "北海道・東北",
+    prefectures: ["北海道", "青森県", "岩手県", "宮城県", "秋田県", "山形県", "福島県"],
+  },
+  { label: "関東", prefectures: ["茨城県", "栃木県", "群馬県", "埼玉県", "千葉県", "神奈川県"] },
+  {
+    label: "中部",
+    prefectures: ["新潟県", "富山県", "石川県", "福井県", "山梨県", "長野県", "岐阜県", "静岡県"],
+  },
+  { label: "近畿", prefectures: ["三重県", "滋賀県", "兵庫県", "奈良県", "和歌山県"] },
+  {
+    label: "中国・四国",
+    prefectures: ["鳥取県", "島根県", "岡山県", "広島県", "徳島県", "香川県", "愛媛県", "高知県"],
+  },
+  {
+    label: "九州・沖縄",
+    prefectures: ["福岡県", "佐賀県", "長崎県", "熊本県", "大分県", "宮崎県", "鹿児島県", "沖縄県"],
+  },
+] as const;
+
+export const PREFECTURES = [
+  ...FREQUENT_PREFECTURES,
+  ...PREFECTURE_GROUPS.flatMap(({ prefectures }) => prefectures),
+] as const;

--- a/apps/cafelog/src/pages/LogDetail.tsx
+++ b/apps/cafelog/src/pages/LogDetail.tsx
@@ -9,6 +9,7 @@ import {
   ExternalLink,
   Loader2,
   MessageSquare,
+  MapPin,
   Star,
   Trash2,
 } from "lucide-react";
@@ -28,6 +29,7 @@ import {
 const toFormValues = (log: LogResponse): CafeLogFormValues => ({
   cafeName: log.cafeName,
   cafeUrl: log.cafeUrl ?? "",
+  prefecture: log.prefecture ?? "",
   origin: log.origin ?? "",
   region: log.region ?? "",
   variety: log.variety ?? "",
@@ -254,6 +256,12 @@ const LogDetailPage = () => {
               <h3 className="text-xl font-bold text-cafe-text leading-tight break-words">
                 {log.cafeName}
               </h3>
+              {log.prefecture && (
+                <p className="flex items-center gap-1 text-xs font-semibold text-cafe-secondary">
+                  <MapPin size={12} />
+                  {log.prefecture}
+                </p>
+              )}
               {log.cafeUrl && (
                 <a
                   href={log.cafeUrl}


### PR DESCRIPTION
### Motivation
- ユーザがカフェ記録に都道府県を入力できるようにして、よく行く都道府県を先頭に表示する選択UXを提供するため。

### Description
- 追加ファイル `src/lib/prefectures.ts` を作成して「よく行く5都府県」と地域別グルーピング、全47都道府県リストを定義した。  
- DBスキーマに `prefecture` カラムを追加し、Drizzleマイグレーション (`apps/cafelog/db/migrations/0009_unknown_arclight.sql`) を生成した。  
- フォームモデルとバリデーションを拡張して `prefecture` を扱うようにし、未選択は `null` としてペイロードに変換するようにした (`src/lib/cafeLogForm.ts`)。  
- UIに都道府県のセレクトボックスを追加し、よく行く都道府県を先頭に、残りをオプトグループで地域別に並べる実装を行った (`src/components/CafeLogForm.tsx`)。  
- APIの作成・更新スキーマに都道府県検証を追加し、許容される値を47都道府県に制限した (`src/api/index.ts`)。  
- 記録編集で既存の都道府県を復元するようにし、詳細画面で店舗名の下に都道府県を表示するようにした (`src/pages/LogDetail.tsx`)。  
- フォームと都道府県リストに関するユニットテストを追加・更新した (`src/lib/cafeLogForm.test.ts`)。

### Testing
- `vp test` (アプリ内テスト) を実行し、該当テストスイートは `19` テスト全て成功しました。  
- `vp build` を実行してビルドが成功することを確認しました。  
- `vp check --fix` はローカルの `vp` バイナリで実行して一部のチェックを実行しましたが、`pnpm` の取得で Corepack がプロキシ制限により失敗したため `pnpm --filter cafelog check:fix` は実行できませんでした。  
- プロジェクトのシークレット検査スクリプト `./scripts/check-betterleaks-canary.sh` は実行環境に `betterleaks` が無いため実行できませんでした; CI上では通常のガードを実行してください。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9acde9498083218c3a02de9ac68302)