### PR TITLE
Cafelog と Brewlog のヘッダーを削除

### DIFF
--- a/apps/brewlog/src/App.tsx
+++ b/apps/brewlog/src/App.tsx
@@ -36,10 +36,6 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
 
   return (
     <div className="flex flex-col min-h-screen bg-coffee-background text-coffee-text">
-      <header className="sticky top-0 z-10 bg-white/80 backdrop-blur-md border-b border-coffee-secondary/20 p-4">
-        <h1 className="text-xl font-bold text-coffee-primary tracking-tight">Brewlog</h1>
-      </header>
-
       <main className="flex-1 pb-24 p-4 max-w-md mx-auto w-full">{children}</main>
 
       <nav className="fixed bottom-0 left-0 right-0 bg-white/95 backdrop-blur-md border-t border-coffee-secondary/15 flex justify-around items-center px-4 py-2 pb-8 z-20 shadow-lg shadow-coffee-primary/5">

--- a/apps/cafelog/src/App.tsx
+++ b/apps/cafelog/src/App.tsx
@@ -28,10 +28,6 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
 
   return (
     <div className="flex flex-col min-h-screen bg-cafe-background text-cafe-text">
-      <header className="sticky top-0 z-10 bg-white/80 backdrop-blur-md border-b border-cafe-secondary/20 p-4">
-        <h1 className="text-xl font-bold text-cafe-primary tracking-tight">Cafelog</h1>
-      </header>
-
       <main className="flex-1 pb-24 p-4 max-w-md mx-auto w-full">{children}</main>
 
       <nav className="fixed bottom-0 left-0 right-0 bg-white/95 backdrop-blur-md border-t border-cafe-secondary/15 flex justify-around items-center px-4 py-2 pb-8 z-20 shadow-lg shadow-cafe-primary/5">


### PR DESCRIPTION
### Motivation
- Cafelog と Brewlog の画面上部にある白背景でアプリ名を表示する固定ヘッダーが不要なため、UI を簡潔にする目的で削除する。メインコンテンツとボトムナビゲーションのレイアウトは維持する。 

### Description
- `apps/cafelog/src/App.tsx` のヘッダー `<header>…Cafelog…</header>` ブロックを削除し、メイン領域とボトムナビはそのまま残した。 
- `apps/brewlog/src/App.tsx` のヘッダー `<header>…Brewlog…</header>` ブロックを同様に削除した。 
- レイアウトおよびナビゲーション実装には手を加えておらず、見た目のヘッダー要素のみを削除する軽微な差分のみを適用した。 

### Testing
- `vp check --fix`（Cafelog）を実行してフォーマット／lint を通した（成功）。
- `vp check --fix`（Brewlog）を実行してフォーマット／lint を通した（成功）。
- `vp test && vp build`（Cafelog）の実行でユニットテスト 15 件が全て成功しビルド成功。 
- `vp test && vp build`（Brewlog）の実行でユニットテスト 30 件が全て成功しビルド成功。 
- Playwright を用いた簡易確認でトップの `header` 要素が 0 件であることをスクリーンショットで確認。 
- `./scripts/guard-changes.sh` / `turbo ... guard:changes` は Corepack が `pnpm` を取得しようとした際に環境のプロキシ制限や `betterleaks` が見つからないことにより完走できなかった（ネットワーク環境依存のため手元 CI で再確認が必要）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9c20e842248321a30181cb7cdcd1ea)