### PR TITLE
feat(brewlog): 豆のアーカイブと論理削除に対応

### DIFF
--- a/apps/brewlog/db/migrations/0015_heavy_kinsey_walden.sql
+++ b/apps/brewlog/db/migrations/0015_heavy_kinsey_walden.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "brewlog"."beans" ADD COLUMN "deleted_at" timestamp;

--- a/apps/brewlog/db/migrations/meta/0015_snapshot.json
+++ b/apps/brewlog/db/migrations/meta/0015_snapshot.json
@@ -1,0 +1,653 @@
+{
+  "id": "2411457e-87ea-4b97-ac05-b6d0fde6f1fc",
+  "prevId": "6f1adffd-1945-40ff-ba79-0e9b1f8b031c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "brewlog.beans": {
+      "name": "beans",
+      "schema": "brewlog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parent_bean_id": {
+          "name": "parent_bean_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coffee_type": {
+          "name": "coffee_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regular'"
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_store": {
+          "name": "purchase_store",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roast_level": {
+          "name": "roast_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roast_date": {
+          "name": "roast_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_date": {
+          "name": "purchase_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "process_method": {
+          "name": "process_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "beans_parent_bean_id_beans_id_fk": {
+          "name": "beans_parent_bean_id_beans_id_fk",
+          "tableFrom": "beans",
+          "tableTo": "beans",
+          "schemaTo": "brewlog",
+          "columnsFrom": ["parent_bean_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "beans_household_id_households_id_fk": {
+          "name": "beans_household_id_households_id_fk",
+          "tableFrom": "beans",
+          "tableTo": "households",
+          "schemaTo": "brewlog",
+          "columnsFrom": ["household_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "brewlog.brew_logs": {
+      "name": "brew_logs",
+      "schema": "brewlog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "bean_id": {
+          "name": "bean_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grind_size": {
+          "name": "grind_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "water_temp": {
+          "name": "water_temp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bean_amount": {
+          "name": "bean_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "water_amount": {
+          "name": "water_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brew_date": {
+          "name": "brew_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dripper_id": {
+          "name": "dripper_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grinder_id": {
+          "name": "grinder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_type": {
+          "name": "temp_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hot'"
+        },
+        "ice_amount": {
+          "name": "ice_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yield_amount": {
+          "name": "yield_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drawdown_time": {
+          "name": "drawdown_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blooming_time": {
+          "name": "blooming_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_bypass": {
+          "name": "has_bypass",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "brew_logs_bean_id_beans_id_fk": {
+          "name": "brew_logs_bean_id_beans_id_fk",
+          "tableFrom": "brew_logs",
+          "tableTo": "beans",
+          "schemaTo": "brewlog",
+          "columnsFrom": ["bean_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "brew_logs_user_id_profiles_line_user_id_fk": {
+          "name": "brew_logs_user_id_profiles_line_user_id_fk",
+          "tableFrom": "brew_logs",
+          "tableTo": "profiles",
+          "schemaTo": "brewlog",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["line_user_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "brew_logs_household_id_households_id_fk": {
+          "name": "brew_logs_household_id_households_id_fk",
+          "tableFrom": "brew_logs",
+          "tableTo": "households",
+          "schemaTo": "brewlog",
+          "columnsFrom": ["household_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "brew_logs_dripper_id_drippers_id_fk": {
+          "name": "brew_logs_dripper_id_drippers_id_fk",
+          "tableFrom": "brew_logs",
+          "tableTo": "drippers",
+          "schemaTo": "brewlog",
+          "columnsFrom": ["dripper_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "brew_logs_grinder_id_grinders_id_fk": {
+          "name": "brew_logs_grinder_id_grinders_id_fk",
+          "tableFrom": "brew_logs",
+          "tableTo": "grinders",
+          "schemaTo": "brewlog",
+          "columnsFrom": ["grinder_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "brewlog.brew_pours": {
+      "name": "brew_pours",
+      "schema": "brewlog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "brew_log_id": {
+          "name": "brew_log_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pour_number": {
+          "name": "pour_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "water_amount": {
+          "name": "water_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pour_type": {
+          "name": "pour_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "brew_pours_brew_log_id_brew_logs_id_fk": {
+          "name": "brew_pours_brew_log_id_brew_logs_id_fk",
+          "tableFrom": "brew_pours",
+          "tableTo": "brew_logs",
+          "schemaTo": "brewlog",
+          "columnsFrom": ["brew_log_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "brewlog.drippers": {
+      "name": "drippers",
+      "schema": "brewlog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "drippers_household_id_households_id_fk": {
+          "name": "drippers_household_id_households_id_fk",
+          "tableFrom": "drippers",
+          "tableTo": "households",
+          "schemaTo": "brewlog",
+          "columnsFrom": ["household_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "brewlog.grinders": {
+      "name": "grinders",
+      "schema": "brewlog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fine_max": {
+          "name": "fine_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 6
+        },
+        "medium_fine_max": {
+          "name": "medium_fine_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 9
+        },
+        "medium_max": {
+          "name": "medium_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "medium_coarse_max": {
+          "name": "medium_coarse_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 22
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grinders_household_id_households_id_fk": {
+          "name": "grinders_household_id_households_id_fk",
+          "tableFrom": "grinders",
+          "tableTo": "households",
+          "schemaTo": "brewlog",
+          "columnsFrom": ["household_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "brewlog.households": {
+      "name": "households",
+      "schema": "brewlog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "brewlog.profiles": {
+      "name": "profiles",
+      "schema": "brewlog",
+      "columns": {
+        "line_user_id": {
+          "name": "line_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_household_id_households_id_fk": {
+          "name": "profiles_household_id_households_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "households",
+          "schemaTo": "brewlog",
+          "columnsFrom": ["household_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "brewlog": "brewlog"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/brewlog/db/migrations/meta/_journal.json
+++ b/apps/brewlog/db/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1788386163540,
       "tag": "0014_sturdy_bloodstorm",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1788616961441,
+      "tag": "0015_heavy_kinsey_walden",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/brewlog/db/schema.ts
+++ b/apps/brewlog/db/schema.ts
@@ -61,6 +61,7 @@ export const beans = brewlogSchema.table("beans", {
   processMethod: text("process_method"),
   note: text("note"),
   isArchived: boolean("is_archived").default(false).notNull(),
+  deletedAt: timestamp("deleted_at"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });
 

--- a/apps/brewlog/src/api/index.ts
+++ b/apps/brewlog/src/api/index.ts
@@ -12,7 +12,7 @@ import {
   grinders,
   brewPours,
 } from "../../db/schema";
-import { eq, and, desc } from "drizzle-orm";
+import { eq, and, desc, isNull } from "drizzle-orm";
 import { z } from "zod";
 import { HTTPException } from "hono/http-exception";
 import type { Env } from "./types";
@@ -95,7 +95,7 @@ const api = app
     const db = getDb(c.env.DATABASE_URL);
     return c.json(
       await db.query.beans.findMany({
-        where: eq(beansTable.householdId, householdId),
+        where: and(eq(beansTable.householdId, householdId), isNull(beansTable.deletedAt)),
         orderBy: [desc(beansTable.createdAt)],
       }),
     );
@@ -104,7 +104,11 @@ const api = app
     const householdId = await getHouseholdId(c);
     const db = getDb(c.env.DATABASE_URL);
     const bean = await db.query.beans.findFirst({
-      where: and(eq(beansTable.id, c.req.param("id")), eq(beansTable.householdId, householdId)),
+      where: and(
+        eq(beansTable.id, c.req.param("id")),
+        eq(beansTable.householdId, householdId),
+        isNull(beansTable.deletedAt),
+      ),
     });
     if (!bean) throw new HTTPException(404, { message: "Bean not found" });
     return c.json(bean);
@@ -112,23 +116,70 @@ const api = app
   .post("/api/beans", zValidator("json", createBeanSchema), async (c) => {
     const householdId = await getHouseholdId(c);
     const db = getDb(c.env.DATABASE_URL);
+    const data = c.req.valid("json");
+    if (data.parentBeanId) {
+      const parent = await db.query.beans.findFirst({
+        where: and(
+          eq(beansTable.id, data.parentBeanId),
+          eq(beansTable.householdId, householdId),
+          eq(beansTable.isArchived, false),
+          isNull(beansTable.deletedAt),
+        ),
+      });
+      if (!parent) throw new HTTPException(409, { message: "Archived or missing bean" });
+    }
     const [newBean] = await db
       .insert(beansTable)
-      .values({ ...c.req.valid("json"), householdId })
+      .values({ ...data, householdId })
       .returning();
     return c.json(newBean);
   })
   .patch("/api/beans/:id", zValidator("json", updateBeanSchema), async (c) => {
     const householdId = await getHouseholdId(c);
     const db = getDb(c.env.DATABASE_URL);
+    const data = c.req.valid("json");
+    const existing = await db.query.beans.findFirst({
+      where: and(
+        eq(beansTable.id, c.req.param("id")),
+        eq(beansTable.householdId, householdId),
+        isNull(beansTable.deletedAt),
+      ),
+    });
+    if (!existing) throw new HTTPException(404, { message: "Bean not found" });
+    if (existing.isArchived && !(Object.keys(data).length === 1 && data.isArchived === false)) {
+      throw new HTTPException(409, { message: "Archived beans cannot be edited" });
+    }
     const [updatedBean] = await db
       .update(beansTable)
-      .set(c.req.valid("json"))
-      .where(and(eq(beansTable.id, c.req.param("id")), eq(beansTable.householdId, householdId)))
+      .set(data)
+      .where(
+        and(
+          eq(beansTable.id, c.req.param("id")),
+          eq(beansTable.householdId, householdId),
+          isNull(beansTable.deletedAt),
+        ),
+      )
       .returning();
 
     if (!updatedBean) throw new HTTPException(404, { message: "Bean not found" });
     return c.json(updatedBean);
+  })
+  .delete("/api/beans/:id", async (c) => {
+    const householdId = await getHouseholdId(c);
+    const db = getDb(c.env.DATABASE_URL);
+    const [deletedBean] = await db
+      .update(beansTable)
+      .set({ deletedAt: new Date() })
+      .where(
+        and(
+          eq(beansTable.id, c.req.param("id")),
+          eq(beansTable.householdId, householdId),
+          isNull(beansTable.deletedAt),
+        ),
+      )
+      .returning();
+    if (!deletedBean) throw new HTTPException(404, { message: "Bean not found" });
+    return c.json(deletedBean);
   })
   .get("/api/logs", async (c) => {
     const householdId = await getHouseholdId(c);
@@ -168,6 +219,16 @@ const api = app
     const db = getDb(c.env.DATABASE_URL);
 
     const { pours, ...logData } = c.req.valid("json");
+
+    const selectableBean = await db.query.beans.findFirst({
+      where: and(
+        eq(beansTable.id, logData.beanId),
+        eq(beansTable.householdId, householdId),
+        eq(beansTable.isArchived, false),
+        isNull(beansTable.deletedAt),
+      ),
+    });
+    if (!selectableBean) throw new HTTPException(409, { message: "Bean is not available" });
 
     const result = await db.transaction(async (tx) => {
       const [newLog] = await tx

--- a/apps/brewlog/src/lib/queries.ts
+++ b/apps/brewlog/src/lib/queries.ts
@@ -89,6 +89,7 @@ export type UpdateGrinderRequest = InferRequestType<(typeof api.api.grinders)[":
 export const mutations = {
   createBean: (options: CreateBeanRequest) => parseOkResponse(api.api.beans.$post(options)),
   updateBean: (options: UpdateBeanRequest) => parseOkResponse(api.api.beans[":id"].$patch(options)),
+  deleteBean: (id: string) => parseOkResponse(api.api.beans[":id"].$delete({ param: { id } })),
   createLog: (options: CreateLogRequest) => parseOkResponse(api.api.logs.$post(options)),
   updateLog: (options: UpdateLogRequest) => parseOkResponse(api.api.logs[":id"].$patch(options)),
   createDripper: (options: CreateDripperRequest) =>

--- a/apps/brewlog/src/pages/Beans/BeanDetail.tsx
+++ b/apps/brewlog/src/pages/Beans/BeanDetail.tsx
@@ -1,16 +1,18 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
 import {
   ArrowLeft,
   Coffee,
   CopyPlus,
   Edit2,
+  Archive,
   Loader2,
   MapPin,
   NotebookText,
   Store,
+  Trash2,
 } from "lucide-react";
-import { beanQueries } from "@/lib/queries";
+import { beanQueries, mutations, queryKeys } from "@/lib/queries";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { OriginFlag } from "@/components/ui/OriginFlag";
@@ -28,7 +30,23 @@ const DetailRow = ({ label, value }: { label: string; value: React.ReactNode }) 
 const BeanDetail = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const beanQuery = useQuery(beanQueries.detail(id ?? ""));
+  const archiveMutation = useMutation({
+    mutationFn: ({ beanId, isArchived }: { beanId: string; isArchived: boolean }) =>
+      mutations.updateBean({ param: { id: beanId }, json: { isArchived } }),
+    onSuccess: async (bean) => {
+      queryClient.setQueryData(queryKeys.bean(bean.id), bean);
+      await queryClient.invalidateQueries({ queryKey: queryKeys.beans });
+    },
+  });
+  const deleteMutation = useMutation({
+    mutationFn: mutations.deleteBean,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: queryKeys.beans });
+      void navigate("/beans");
+    },
+  });
 
   if (beanQuery.isPending) {
     return (
@@ -66,6 +84,31 @@ const BeanDetail = () => {
         </Button>
         <h2 className="text-xl font-bold text-coffee-primary">豆の詳細</h2>
       </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <Button
+          variant="outline"
+          className="h-11 rounded-2xl border-coffee-primary/30"
+          disabled={bean.isArchived}
+          onClick={() => navigate(`/beans/new?parentBeanId=${bean.parentBeanId ?? bean.id}`)}
+        >
+          <CopyPlus size={16} className="mr-2" /> バージョン追加
+        </Button>
+        <Button
+          variant="outline"
+          className="h-11 rounded-2xl border-coffee-primary/30"
+          disabled={bean.isArchived}
+          onClick={() => navigate(`/beans/${bean.id}/edit`)}
+        >
+          <Edit2 size={16} className="mr-2" /> 編集
+        </Button>
+      </div>
+
+      {bean.isArchived && (
+        <p className="rounded-xl bg-coffee-secondary/10 px-4 py-3 text-sm text-coffee-secondary">
+          この豆はアーカイブ済みのため、編集・バージョン追加・抽出記録はできません。
+        </p>
+      )}
 
       <Card className="overflow-hidden border-2 border-coffee-primary/10 shadow-md">
         <div className="bg-coffee-primary/5 p-5">
@@ -124,28 +167,42 @@ const BeanDetail = () => {
       </Card>
 
       <div className="space-y-3">
-        <div className="grid grid-cols-2 gap-3">
+        <Button
+          className="h-12 w-full rounded-2xl shadow-md"
+          disabled={bean.isArchived}
+          onClick={() => navigate(`/logs/new?beanId=${bean.id}`)}
+        >
+          <Coffee size={18} className="mr-2" /> 淹れる
+        </Button>
+        <div className="flex flex-col items-center gap-1">
           <Button
-            variant="outline"
-            className="h-12 rounded-2xl border-coffee-primary/30"
-            onClick={() => navigate(`/beans/${bean.id}/edit`)}
+            variant="ghost"
+            disabled={archiveMutation.isPending || deleteMutation.isPending}
+            onClick={() =>
+              archiveMutation.mutate({ beanId: bean.id, isArchived: !bean.isArchived })
+            }
           >
-            <Edit2 size={17} className="mr-2" /> 編集する
+            <Archive size={16} className="mr-2" />
+            {bean.isArchived ? "アーカイブから戻す" : "アーカイブする"}
           </Button>
           <Button
-            className="h-12 rounded-2xl shadow-md"
-            onClick={() => navigate(`/logs/new?beanId=${bean.id}`)}
+            variant="ghost"
+            className="text-red-600 hover:bg-red-50 hover:text-red-700"
+            disabled={archiveMutation.isPending || deleteMutation.isPending}
+            onClick={() => {
+              if (window.confirm("この豆を削除しますか？抽出記録は削除されません。")) {
+                deleteMutation.mutate(bean.id);
+              }
+            }}
           >
-            <Coffee size={18} className="mr-2" /> 淹れる
+            <Trash2 size={16} className="mr-2" /> 削除する
           </Button>
         </div>
-        <Button
-          variant="outline"
-          className="h-12 w-full rounded-2xl border-coffee-primary/30"
-          onClick={() => navigate(`/beans/new?parentBeanId=${bean.parentBeanId ?? bean.id}`)}
-        >
-          <CopyPlus size={17} className="mr-2" /> 同じ豆の新しいバージョンを追加する
-        </Button>
+        {(archiveMutation.isError || deleteMutation.isError) && (
+          <p className="text-center text-sm text-red-600">
+            操作に失敗しました。もう一度お試しください。
+          </p>
+        )}
       </div>
     </div>
   );

--- a/apps/brewlog/src/pages/Beans/BeansList.tsx
+++ b/apps/brewlog/src/pages/Beans/BeansList.tsx
@@ -1,7 +1,16 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { Plus, Coffee, ChevronRight, Loader2, Pencil, Sparkles } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowUp,
+  Plus,
+  Coffee,
+  ChevronRight,
+  Loader2,
+  Pencil,
+  Sparkles,
+} from "lucide-react";
 import { beanQueries, logQueries, type Bean } from "@/lib/queries";
 import { Button } from "../../components/ui/button";
 import { Card, CardContent } from "../../components/ui/card";
@@ -14,33 +23,32 @@ const BeansList = () => {
   const navigate = useNavigate();
   const beansQuery = useQuery(beanQueries.all());
   const logsQuery = useQuery(logQueries.all());
+  const [showArchived, setShowArchived] = useState(false);
+  const [sortBy, setSortBy] = useState<"date" | "name" | "brews">("date");
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
 
-  const beans = beansQuery.data ?? [];
-  const activeBeans = beans.filter((bean) => !bean.isArchived);
+  const beans = useMemo(() => beansQuery.data ?? [], [beansQuery.data]);
 
   const groupedBeans = useMemo(() => {
     const groups: Record<string, Bean[]> = {};
-    activeBeans.forEach((bean) => {
+    beans.forEach((bean) => {
       const groupId = bean.parentBeanId || bean.id;
       if (!groups[groupId]) groups[groupId] = [];
       groups[groupId].push(bean);
     });
 
-    return Object.entries(groups)
-      .map(([groupId, groupBeans]) => {
-        const sorted = [...groupBeans].toSorted(
-          (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-        );
-        return {
-          groupId,
-          latestBean: sorted[0],
-        };
-      })
-      .toSorted(
-        (a, b) =>
-          new Date(b.latestBean.createdAt).getTime() - new Date(a.latestBean.createdAt).getTime(),
+    return Object.entries(groups).map(([groupId, groupBeans]) => {
+      const sorted = [...groupBeans].toSorted(
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
       );
-  }, [activeBeans]);
+      const latestBean = sorted[0];
+      return {
+        groupId,
+        latestBean,
+        isArchived: latestBean.isArchived,
+      };
+    });
+  }, [beans]);
 
   const brewCountByGroupId = useMemo(() => {
     const counts = new Map<string, number>();
@@ -53,6 +61,31 @@ const BeansList = () => {
     }
     return counts;
   }, [beansQuery.data, logsQuery.data]);
+
+  const visibleBeans = useMemo(() => {
+    const groups = groupedBeans.filter((group) => showArchived || !group.isArchived);
+    return groups.toSorted((a, b) => {
+      let comparison: number;
+      if (sortBy === "name") {
+        comparison = a.latestBean.name.localeCompare(b.latestBean.name, "ja");
+      } else if (sortBy === "brews") {
+        comparison =
+          (brewCountByGroupId.get(a.groupId) ?? 0) - (brewCountByGroupId.get(b.groupId) ?? 0);
+      } else {
+        comparison =
+          new Date(a.latestBean.createdAt).getTime() - new Date(b.latestBean.createdAt).getTime();
+      }
+      return sortOrder === "asc" ? comparison : -comparison;
+    });
+  }, [brewCountByGroupId, groupedBeans, showArchived, sortBy, sortOrder]);
+
+  const changeSort = (nextSort: typeof sortBy) => {
+    if (sortBy === nextSort) setSortOrder((order) => (order === "asc" ? "desc" : "asc"));
+    else {
+      setSortBy(nextSort);
+      setSortOrder(nextSort === "name" ? "asc" : "desc");
+    }
+  };
 
   if (beansQuery.isPending) {
     return (
@@ -87,6 +120,34 @@ const BeansList = () => {
         </Button>
       </div>
 
+      {groupedBeans.length > 0 && (
+        <div className="space-y-2 rounded-2xl border border-coffee-primary/10 bg-coffee-primary/5 p-3">
+          <label className="flex min-h-11 cursor-pointer items-center justify-between gap-3 text-sm font-semibold text-coffee-primary">
+            <span>アーカイブも表示</span>
+            <input
+              type="checkbox"
+              checked={showArchived}
+              onChange={(event) => setShowArchived(event.target.checked)}
+              className="h-5 w-5 accent-coffee-primary"
+            />
+          </label>
+          <div className="grid grid-cols-3 gap-1 rounded-xl bg-white/60 p-1">
+            {(["date", "name", "brews"] as const).map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => changeSort(option)}
+                className={`flex min-h-11 items-center justify-center rounded-lg text-xs font-semibold ${sortBy === option ? "bg-white text-coffee-primary shadow-sm" : "text-coffee-secondary"}`}
+              >
+                {option === "date" ? "登録日" : option === "name" ? "豆名" : "抽出回数"}
+                {sortBy === option &&
+                  (sortOrder === "desc" ? <ArrowDown size={12} /> : <ArrowUp size={12} />)}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
       {logsQuery.isError && (
         <div
           className="flex items-center justify-between gap-3 rounded-xl bg-coffee-secondary/10 px-4 py-3 text-xs text-coffee-secondary"
@@ -104,11 +165,15 @@ const BeansList = () => {
         </div>
       )}
 
-      {groupedBeans.length === 0 ? (
+      {visibleBeans.length === 0 ? (
         <Card className="border-dashed border-2">
           <CardContent className="p-12 text-center">
             <Coffee className="mx-auto text-coffee-secondary/30 mb-4" size={48} />
-            <p className="text-coffee-secondary text-sm">登録されている豆はありません。</p>
+            <p className="text-coffee-secondary text-sm">
+              {groupedBeans.length > 0
+                ? "表示できる豆はありません。"
+                : "登録されている豆はありません。"}
+            </p>
             <p className="text-xs text-coffee-secondary/60 mt-2">
               お気に入りの豆を登録しましょう！
             </p>
@@ -119,7 +184,7 @@ const BeansList = () => {
         </Card>
       ) : (
         <div className="space-y-3">
-          {groupedBeans.map((group) => {
+          {visibleBeans.map((group) => {
             const { latestBean } = group;
             const brewCount = brewCountByGroupId.get(group.groupId) ?? 0;
             const displayDate = latestBean.purchaseDate ?? latestBean.roastDate;
@@ -167,6 +232,11 @@ const BeansList = () => {
                     </div>
                     <div className="min-w-0 flex-1 space-y-1.5">
                       <h3 className="font-bold text-coffee-text truncate">{latestBean.name}</h3>
+                      {group.isArchived && (
+                        <span className="inline-flex rounded-full bg-coffee-secondary/15 px-2 py-0.5 text-[10px] font-bold text-coffee-secondary">
+                          アーカイブ済み
+                        </span>
+                      )}
                       <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-coffee-secondary">
                         <span
                           className={`inline-flex items-center gap-1 font-medium ${
@@ -214,11 +284,12 @@ const BeansList = () => {
                   </div>
                   <div className="flex items-center space-x-1 flex-shrink-0 rounded-full bg-white/75 p-0.5 shadow-sm backdrop-blur-[2px]">
                     <button
+                      disabled={group.isArchived}
                       onClick={(e) => {
                         e.stopPropagation();
                         void navigate(`/beans/${latestBean.id}/edit`);
                       }}
-                      className="p-2 text-coffee-secondary hover:text-coffee-primary hover:bg-coffee-secondary/10 rounded-full transition-colors"
+                      className="p-2 text-coffee-secondary hover:text-coffee-primary hover:bg-coffee-secondary/10 rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-30"
                       title="最新の豆を編集"
                     >
                       <Pencil size={16} />

--- a/apps/brewlog/src/pages/Logs/AddLog.tsx
+++ b/apps/brewlog/src/pages/Logs/AddLog.tsx
@@ -27,13 +27,13 @@ const AddLog = () => {
       if (!previous || new Date(bean.createdAt).getTime() > new Date(previous.createdAt).getTime())
         latest.set(groupId, bean);
     }
-    const unique = [...latest.values()].toSorted(
-      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-    );
+    const unique = [...latest.values()]
+      .filter((bean) => !bean.isArchived)
+      .toSorted((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
     const paramBeanId = searchParams.get("beanId");
     if (paramBeanId && !unique.some((bean) => bean.id === paramBeanId)) {
       const selected = source.find((bean) => bean.id === paramBeanId);
-      if (selected) unique.unshift(selected);
+      if (selected && !selected.isArchived) unique.unshift(selected);
     }
     return unique;
   }, [allBeans, searchParams]);


### PR DESCRIPTION
### Motivation
- 豆が増えると一覧が長くなり選択が煩雑になるため、アーカイブ機能で表示対象から外し編集や新バージョン作成を制限するための対応。 
- 削除は論理削除(`deleted_at`)にして、既存の抽出記録には影響を与えないようにするため。 

### Description
- DB: `beans` テーブルに nullable な `deleted_at` カラムを追加し、Drizzle 生成のマイグレーション `db/migrations/0015_heavy_kinsey_walden.sql` を追加。 
- API: 諸処で `deleted_at` を無視するようにクエリを更新し、親豆がアーカイブ/削除済みの場合のバージョン作成を拒否し、アーカイブ済みは編集不可（ただし復元のみ可能）にし、`DELETE /api/beans/:id` による論理削除を追加し、抽出記録作成時にアーカイブ/削除済みの豆は選択できないよう検証を追加。 
- Frontend: 豆一覧に「アーカイブも表示」トグルと登録日/豆名/抽出回数でのソートを追加し、アーカイブ済みグループのバッジ表示と編集操作の無効化を実装し、豆詳細にアーカイブ/復元/削除ボタンを追加してアーカイブ時は編集・バージョン追加・淹れる操作を無効化し、記録作成フォームではアーカイブ済み豆を選択肢から除外し、クライアント側のクエリに `deleteBean` ミューテーションを追加。 

### Testing
- `vp check --fix` を実行しフォーマットとリンティングの修正を反映済みで成功。 
- `vp test` を実行してテストは全て通過（31 tests passed）。 
- `vp build` を実行してビルド成功。 
- Drizzle マイグレーションは生成済みですが、環境の Corepack/pnpm ダウンロードで一時的に失敗が発生したため（プロキシ/403）、ローカルにインストール済みの Drizzle バイナリでマイグレーションを作成しています。 
- `./apps/brewlog/scripts/guard-changes.sh` の一部実行は Corepack / `betterleaks` の環境依存で失敗しましたが、チェックとテスト本体は通過しています。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9c2055b94c8321b97f57ba03735e66)